### PR TITLE
Convert TF2 bot code references to FF equivalents

### DIFF
--- a/mp/src/game/server/ff/bot/behavior/demoman/tf_bot_prepare_stickybomb_trap.cpp
+++ b/mp/src/game/server/ff/bot/behavior/demoman/tf_bot_prepare_stickybomb_trap.cpp
@@ -180,7 +180,7 @@ ActionResult< CFFBot >	CFFBotPrepareStickybombTrap::OnStart( CFFBot *me, Action<
 //---------------------------------------------------------------------------------------------
 ActionResult< CFFBot >	CFFBotPrepareStickybombTrap::Update( CFFBot *me, float interval )
 {
-	if ( !TFGameRules()->InSetup() )
+	if ( !FFGameRules()->InSetup() )
 	{
 		const CKnownEntity *threat = me->GetVisionInterface()->GetPrimaryKnownThreat();
 		if ( threat )

--- a/mp/src/game/server/ff/bot/behavior/demoman/tf_bot_stickybomb_sentrygun.cpp
+++ b/mp/src/game/server/ff/bot/behavior/demoman/tf_bot_stickybomb_sentrygun.cpp
@@ -150,7 +150,7 @@ ActionResult< CFFBot >	CFFBotStickybombSentrygun::Update( CFFBot *me, float inte
 
 	int requiredStickyBombs = 3;
 
-	if ( TFGameRules()->IsMannVsMachineMode() )
+	if ( FFGameRules()->IsMannVsMachineMode() )
 	{
 		// launch more stickies to make sure we take out beefed-up sentries
 		requiredStickyBombs = 5;

--- a/mp/src/game/server/ff/bot/behavior/engineer/mvm_engineer/tf_bot_mvm_engineer_build_sentry.cpp
+++ b/mp/src/game/server/ff/bot/behavior/engineer/mvm_engineer/tf_bot_mvm_engineer_build_sentry.cpp
@@ -74,7 +74,7 @@ ActionResult< CFFBot >	CFFBotMvMEngineerBuildSentryGun::Update( CFFBot *me, floa
 	if ( !m_delayBuildTime.HasStarted() )
 	{
 		m_delayBuildTime.Start( 0.1f );
-		TFGameRules()->PushAllPlayersAway( m_sentryBuildHint->GetAbsOrigin(), 400, 500, FF_TEAM_RED );
+		FFGameRules()->PushAllPlayersAway( m_sentryBuildHint->GetAbsOrigin(), 400, 500, FF_TEAM_RED );
 	}
 	else if ( m_delayBuildTime.HasStarted() && m_delayBuildTime.IsElapsed() )
 	{

--- a/mp/src/game/server/ff/bot/behavior/engineer/mvm_engineer/tf_bot_mvm_engineer_build_teleporter.cpp
+++ b/mp/src/game/server/ff/bot/behavior/engineer/mvm_engineer/tf_bot_mvm_engineer_build_teleporter.cpp
@@ -63,7 +63,7 @@ ActionResult< CFFBot >	CFFBotMvMEngineerBuildTeleportExit::Update( CFFBot *me, f
 	if ( !m_delayBuildTime.HasStarted() )
 	{
 		m_delayBuildTime.Start( 0.1f );
-		TFGameRules()->PushAllPlayersAway( m_teleporterBuildHint->GetAbsOrigin(), 400, 500, FF_TEAM_RED );
+		FFGameRules()->PushAllPlayersAway( m_teleporterBuildHint->GetAbsOrigin(), 400, 500, FF_TEAM_RED );
 	}
 	else if ( m_delayBuildTime.IsElapsed() )
 	{

--- a/mp/src/game/server/ff/bot/behavior/engineer/mvm_engineer/tf_bot_mvm_engineer_teleport_spawn.cpp
+++ b/mp/src/game/server/ff/bot/behavior/engineer/mvm_engineer/tf_bot_mvm_engineer_teleport_spawn.cpp
@@ -43,7 +43,7 @@ ActionResult< CFFBot >	CFFBotMvMEngineerTeleportSpawn::Update( CFFBot *me, float
 	{
 		m_teleportDelay.Start( 0.1f );
 		if ( m_hintEntity )
-			TFGameRules()->PushAllPlayersAway( m_hintEntity->GetAbsOrigin(), 400, 500, FF_TEAM_RED );
+			FFGameRules()->PushAllPlayersAway( m_hintEntity->GetAbsOrigin(), 400, 500, FF_TEAM_RED );
 	}
 	else if ( m_teleportDelay.IsElapsed() )
 	{
@@ -75,11 +75,11 @@ ActionResult< CFFBot >	CFFBotMvMEngineerTeleportSpawn::Update( CFFBot *me, float
 				{
 					if ( pWave->NumEngineersTeleportSpawned() == 0 )
 					{
-						TFGameRules()->BroadcastSound( 255, "Announcer.MVM_First_Engineer_Teleport_Spawned" );
+						FFGameRules()->BroadcastSound( 255, "Announcer.MVM_First_Engineer_Teleport_Spawned" );
 					}
 					else
 					{
-						TFGameRules()->BroadcastSound( 255, "Announcer.MVM_Another_Engineer_Teleport_Spawned" );
+						FFGameRules()->BroadcastSound( 255, "Announcer.MVM_Another_Engineer_Teleport_Spawned" );
 					}
 
 					pWave->IncrementEngineerTeleportSpawned();

--- a/mp/src/game/server/ff/bot/behavior/engineer/tf_bot_engineer_build.cpp
+++ b/mp/src/game/server/ff/bot/behavior/engineer/tf_bot_engineer_build.cpp
@@ -26,7 +26,7 @@ ConVar ff_raid_engineer_infinte_metal( "ff_raid_engineer_infinte_metal", "1", FC
 //---------------------------------------------------------------------------------------------
 Action< CFFBot > *CFFBotEngineerBuild::InitialContainedAction( CFFBot *me )
 {
-	if ( TFGameRules()->IsPVEModeActive() )
+	if ( FFGameRules()->IsPVEModeActive() )
 	{
 		return new CFFBotEngineerMoveToBuild;
 	}
@@ -45,7 +45,7 @@ ActionResult< CFFBot >	CFFBotEngineerBuild::OnStart( CFFBot *me, Action< CFFBot 
 //---------------------------------------------------------------------------------------------
 ActionResult< CFFBot >	CFFBotEngineerBuild::Update( CFFBot *me, float interval )
 {
-	if ( TFGameRules()->IsPVEModeActive() && ff_raid_engineer_infinte_metal.GetBool() )
+	if ( FFGameRules()->IsPVEModeActive() && ff_raid_engineer_infinte_metal.GetBool() )
 	{
 		// infinite ammo
 		me->GiveAmmo( 1000, TF_AMMO_METAL, true );

--- a/mp/src/game/server/ff/bot/behavior/engineer/tf_bot_engineer_building.cpp
+++ b/mp/src/game/server/ff/bot/behavior/engineer/tf_bot_engineer_building.cpp
@@ -380,7 +380,7 @@ ActionResult< CFFBot >	CFFBotEngineerBuilding::Update( CFFBot *me, float interva
 */
 
 	// try to build a Dispenser (build after tele exit in training)
-	if ( !TFGameRules()->IsInTraining() || myTeleportExit )
+	if ( !FFGameRules()->IsInTraining() || myTeleportExit )
 	{
 		const float dispenserRebuildInterval = 10.0f;
 		if ( myDispenser )
@@ -397,7 +397,7 @@ ActionResult< CFFBot >	CFFBotEngineerBuilding::Update( CFFBot *me, float interva
 	}
 
 	// try to build a Teleporter Exit
-	const float exitRebuildInterval = TFGameRules()->IsInTraining() ? 5.0f : 30.0f;
+	const float exitRebuildInterval = FFGameRules()->IsInTraining() ? 5.0f : 30.0f;
 	if ( myTeleportExit )
 	{
 		// don't rebuild immediately after building is destroyed

--- a/mp/src/game/server/ff/bot/behavior/engineer/tf_bot_engineer_move_to_build.cpp
+++ b/mp/src/game/server/ff/bot/behavior/engineer/tf_bot_engineer_move_to_build.cpp
@@ -120,7 +120,7 @@ void CFFBotEngineerMoveToBuild::CollectBuildAreas( CFFBot *me )
 			if ( visibleArea->GetIncursionDistance( myTeam ) < 0 || visibleArea->GetIncursionDistance( enemyTeam ) < 0 )
 				continue;
 
-			if ( TFGameRules()->IsInKothMode() )
+			if ( FFGameRules()->IsInKothMode() )
 			{
 				// ignore areas the enemy can reach first
 				if ( visibleArea->GetIncursionDistance( myTeam ) >= visibleArea->GetIncursionDistance( enemyTeam ) )
@@ -134,7 +134,7 @@ void CFFBotEngineerMoveToBuild::CollectBuildAreas( CFFBot *me )
 // 					continue;
 // 			}
 
-			if ( TFGameRules()->GetGameType() == TF_GAMETYPE_CP )
+			if ( FFGameRules()->GetGameType() == TF_GAMETYPE_CP )
 			{
 				// don't build directly on the point
 				if ( visibleArea->HasAttributeTF( TF_NAV_CONTROL_POINT ) )
@@ -273,12 +273,12 @@ ActionResult< CFFBot >	CFFBotEngineerMoveToBuild::OnStart( CFFBot *me, Action< C
 	m_path.SetMinLookAheadDistance( me->GetDesiredPathLookAheadRange() );
 
 #ifdef TF_RAID_MODE
-	if ( TFGameRules()->IsRaidMode() )
+	if ( FFGameRules()->IsRaidMode() )
 	{
-		if ( me->GetHomeArea() && TFGameRules()->GetRaidLogic() )
+		if ( me->GetHomeArea() && FFGameRules()->GetRaidLogic() )
 		{
 			// try to pick a new area
-			CTFNavArea *sentryArea = TFGameRules()->GetRaidLogic()->SelectRaidSentryArea();
+			CTFNavArea *sentryArea = FFGameRules()->GetRaidLogic()->SelectRaidSentryArea();
 			if ( sentryArea )
 			{
 				me->SetHomeArea( sentryArea );
@@ -334,7 +334,7 @@ ActionResult< CFFBot >	CFFBotEngineerMoveToBuild::Update( CFFBot *me, float inte
 	}
 
 	// offensive engineers need to place a forward teleporter
-	if ( TFGameRules()->GetGameType() == TF_GAMETYPE_CP && !TFGameRules()->IsInKothMode() && me->GetTeamNumber() == FF_TEAM_BLUE )
+	if ( FFGameRules()->GetGameType() == TF_GAMETYPE_CP && !FFGameRules()->IsInKothMode() && me->GetTeamNumber() == FF_TEAM_BLUE )
 	{
 		CObjectTeleporter *myTeleportExit = (CObjectTeleporter *)me->GetObjectOfType( OBJ_TELEPORTER, MODE_TELEPORTER_EXIT );
 		int myTeam = me->GetTeamNumber();

--- a/mp/src/game/server/ff/bot/behavior/medic/tf_bot_medic_heal.cpp
+++ b/mp/src/game/server/ff/bot/behavior/medic/tf_bot_medic_heal.cpp
@@ -75,7 +75,7 @@ public:
 
 		int i;
 
-		if ( TFGameRules()->IsInTraining() )
+		if ( FFGameRules()->IsInTraining() )
 		{
 			// in training mode, stay on the human trainee
 			if ( !current || current->IsBot() )
@@ -272,7 +272,7 @@ CFFPlayer *CFFBotMedicHeal::SelectPatient( CFFBot *me, CFFPlayer *current )
 
 	CSelectPrimaryPatient choose( me, current );
 
-	if ( TFGameRules()->IsPVEModeActive() )
+	if ( FFGameRules()->IsPVEModeActive() )
 	{
 		// assume perfect knowledge
 		CUtlVector< CFFPlayer * > livePlayerVector;
@@ -399,7 +399,7 @@ public:
 bool CFFBotMedicHeal::CanDeployUber( CFFBot *me, const CWeaponMedigun* pMedigun ) const
 {
 #ifdef STAGING_ONLY
-	if ( TFGameRules()->IsMannVsMachineMode() && 
+	if ( FFGameRules()->IsMannVsMachineMode() && 
 			me && me->HasAttribute( CFFBot::PROJECTILE_SHIELD ) && 
 			pMedigun && ( pMedigun->GetMedigunShield() != NULL ) && pMedigun->HasPermanentShield() && ( ( pMedigun->GetMedigunType() == MEDIGUN_STANDARD ) || ( pMedigun->GetMedigunType() == MEDIGUN_UBER ) ) )
 	{
@@ -425,7 +425,7 @@ bool CFFBotMedicHeal::IsReadyToDeployUber( const CWeaponMedigun* pMedigun ) cons
 	if ( pMedigun->GetChargeLevel() < pMedigun->GetMinChargeAmount() )
 		return false;
 	
-	if ( TFGameRules()->InSetup() )
+	if ( FFGameRules()->InSetup() )
 		return false;
 	
 	return true;
@@ -455,7 +455,7 @@ ActionResult< CFFBot >	CFFBotMedicHeal::Update( CFFBot *me, float interval )
 	if ( me->IsInASquad() )
 	{
 		CFFBotSquad *squad = me->GetSquad();
-		if ( TFGameRules() && TFGameRules()->IsMannVsMachineMode() && squad->IsLeader( me ) )
+		if ( FFGameRules() && FFGameRules()->IsMannVsMachineMode() && squad->IsLeader( me ) )
 		{
 			return ChangeTo( new CFFBotFetchFlag, "I'm now a squad leader! Going for the flag!" );
 		}
@@ -493,7 +493,7 @@ ActionResult< CFFBot >	CFFBotMedicHeal::Update( CFFBot *me, float interval )
 	m_patient = SelectPatient( me, m_patient );
 
 	// prevent a group of medic healing each other in a loop. always heal the top guy in the chain
-	if ( TFGameRules() && TFGameRules()->IsMannVsMachineMode() && m_patient != NULL && m_patient->IsPlayerClass( CLASS_MEDIC ) )
+	if ( FFGameRules() && FFGameRules()->IsMannVsMachineMode() && m_patient != NULL && m_patient->IsPlayerClass( CLASS_MEDIC ) )
 	{
 		CUtlVector< CBaseEntity* > seenPatients;
 		seenPatients.AddToTail( m_patient );
@@ -514,13 +514,13 @@ ActionResult< CFFBot >	CFFBotMedicHeal::Update( CFFBot *me, float interval )
 	{
 		// no patients
 
-		if ( TFGameRules()->IsMannVsMachineMode() )
+		if ( FFGameRules()->IsMannVsMachineMode() )
 		{
 			// no-one is left to heal - get the flag!
 			return ChangeTo( new CFFBotFetchFlag, "Everyone is gone! Going for the flag" );
 		}
 
-		if ( TFGameRules()->IsPVEModeActive() )
+		if ( FFGameRules()->IsPVEModeActive() )
 		{
 			// don't retreat, just wait
 			return Continue();
@@ -597,7 +597,7 @@ ActionResult< CFFBot >	CFFBotMedicHeal::Update( CFFBot *me, float interval )
 		// if our primary patient is healthy and safe, heal others in our immediate vicinity who need it
 		// No opportunistic healing in training - focus on the trainee
 		// No opportunistic healing if I'm in a squad - stay on the leader
-		if ( !medigun->IsReleasingCharge() && IsStable( m_patient ) && !TFGameRules()->IsInTraining() && !me->IsInASquad() )
+		if ( !medigun->IsReleasingCharge() && IsStable( m_patient ) && !FFGameRules()->IsInTraining() && !me->IsInASquad() )
 		{
 			bool isInCombat = actualHealTarget ? actualHealTarget->GetTimeSinceWeaponFired() < 1.0f : false;
 
@@ -668,7 +668,7 @@ ActionResult< CFFBot >	CFFBotMedicHeal::Update( CFFBot *me, float interval )
 				// uber if I'm getting low and have recently taken damage
 				if ( me->GetHealth() < me->GetUberHealthThreshold() )
 				{
-					if ( me->GetTimeSinceLastInjury( GetEnemyTeam( me->GetTeamNumber() ) ) < 1.0f || TFGameRules()->IsMannVsMachineMode() )
+					if ( me->GetTimeSinceLastInjury( GetEnemyTeam( me->GetTeamNumber() ) ) < 1.0f || FFGameRules()->IsMannVsMachineMode() )
 					{
 						useUber = true;
 					}
@@ -681,7 +681,7 @@ ActionResult< CFFBot >	CFFBotMedicHeal::Update( CFFBot *me, float interval )
 				}
 
 				// special case for bots in mvm spawn zones
-				if ( TFGameRules()->IsMannVsMachineMode() )
+				if ( FFGameRules()->IsMannVsMachineMode() )
 				{
 					if ( m_patient->m_Shared.InCond( TF_COND_INVULNERABLE_HIDE_UNLESS_DAMAGED ) && 
 						 me->m_Shared.InCond( TF_COND_INVULNERABLE_HIDE_UNLESS_DAMAGED ) )
@@ -710,7 +710,7 @@ ActionResult< CFFBot >	CFFBotMedicHeal::Update( CFFBot *me, float interval )
 		
 #ifdef STAGING_ONLY
 		// try to activate shield when I'm not using uber so I don't waste it
-		if ( TFGameRules()->IsMannVsMachineMode() && me->HasAttribute( CFFBot::PROJECTILE_SHIELD ) && medigun->GetMedigunShield() == NULL )
+		if ( FFGameRules()->IsMannVsMachineMode() && me->HasAttribute( CFFBot::PROJECTILE_SHIELD ) && medigun->GetMedigunShield() == NULL )
 		{
 			// activate shield ASAP for permanent shield medigun
 			if ( medigun->HasPermanentShield() )
@@ -735,7 +735,7 @@ ActionResult< CFFBot >	CFFBotMedicHeal::Update( CFFBot *me, float interval )
 		}
 #else // remove this when we ship medic shield MVM update
 		// try to activate shield when I'm not using uber so I don't waste it
-		if ( TFGameRules()->IsMannVsMachineMode() && me->HasAttribute( CFFBot::PROJECTILE_SHIELD ) )
+		if ( FFGameRules()->IsMannVsMachineMode() && me->HasAttribute( CFFBot::PROJECTILE_SHIELD ) )
 		{
 			isUsingProjectileShield = me->m_Shared.IsRageDraining();
 			// when the rage is ready to deploy and we're not using uber
@@ -947,7 +947,7 @@ void CFFBotMedicHeal::ComputeFollowPosition( CFFBot *me )
 
 	bool isExposed;
 
-	if ( TFGameRules()->IsMannVsMachineMode() && me->GetTeamNumber() == FF_TEAM_PVE_INVADERS )
+	if ( FFGameRules()->IsMannVsMachineMode() && me->GetTeamNumber() == FF_TEAM_PVE_INVADERS )
 	{
 		// robot medics in MvM don't care if the enemy sees them
 		isExposed = false;
@@ -971,7 +971,7 @@ void CFFBotMedicHeal::ComputeFollowPosition( CFFBot *me )
 		{
 			// if we haven't been in combat for awhile, move behind our patient if we're in front of him
 			Vector toPatient = m_patient->GetAbsOrigin() - me->GetAbsOrigin();
-			if ( !TFGameRules()->InSetup() && m_patient->GetTimeSinceWeaponFired() > 5.0f && DotProduct( patientForward, toPatient ) < 0.0f )
+			if ( !FFGameRules()->InSetup() && m_patient->GetTimeSinceWeaponFired() > 5.0f && DotProduct( patientForward, toPatient ) < 0.0f )
 			{
 				m_followGoal = m_patient->GetAbsOrigin() - ff_bot_medic_stop_follow_range.GetFloat() * patientForward;
 			}

--- a/mp/src/game/server/ff/bot/behavior/missions/tf_bot_mission_destroy_sentries.cpp
+++ b/mp/src/game/server/ff/bot/behavior/missions/tf_bot_mission_destroy_sentries.cpp
@@ -61,12 +61,12 @@ ActionResult< CFFBot > CFFBotMissionDestroySentries::Update( CFFBot *me, float i
 			// next destroy the most dangerous sentry
  			int iTeam = ( me->GetTeamNumber() == FF_TEAM_RED ) ? FF_TEAM_BLUE : FF_TEAM_RED;
 
-			if ( TFGameRules() && TFGameRules()->IsPVEModeActive() )
+			if ( FFGameRules() && FFGameRules()->IsPVEModeActive() )
 			{
 				iTeam = FF_TEAM_PVE_DEFENDERS;
 			}
 
-			m_goalSentry = TFGameRules()->FindSentryGunWithMostKills( iTeam );
+			m_goalSentry = FFGameRules()->FindSentryGunWithMostKills( iTeam );
 		}
 	}
 

--- a/mp/src/game/server/ff/bot/behavior/missions/tf_bot_mission_reprogrammed.cpp
+++ b/mp/src/game/server/ff/bot/behavior/missions/tf_bot_mission_reprogrammed.cpp
@@ -253,9 +253,9 @@ void CFFBotMissionReprogrammed::Detonate( CFFBot *me )
 
 	if ( !m_wasSuccessful )
 	{
-		if ( TFGameRules() && TFGameRules()->IsMannVsMachineMode() )
+		if ( FFGameRules() && FFGameRules()->IsMannVsMachineMode() )
 		{
-			TFGameRules()->HaveAllPlayersSpeakConceptIfAllowed( MP_CONCEPT_MVM_SENTRY_BUSTER_DOWN, FF_TEAM_PVE_DEFENDERS );
+			FFGameRules()->HaveAllPlayersSpeakConceptIfAllowed( MP_CONCEPT_MVM_SENTRY_BUSTER_DOWN, FF_TEAM_PVE_DEFENDERS );
 		}
 	}
 

--- a/mp/src/game/server/ff/bot/behavior/missions/tf_bot_mission_suicide_bomber.cpp
+++ b/mp/src/game/server/ff/bot/behavior/missions/tf_bot_mission_suicide_bomber.cpp
@@ -246,9 +246,9 @@ void CFFBotMissionSuicideBomber::Detonate( CFFBot *me )
 
 	if ( !m_bWasSuccessful )
 	{
-		if ( TFGameRules() && TFGameRules()->IsMannVsMachineMode() )
+		if ( FFGameRules() && FFGameRules()->IsMannVsMachineMode() )
 		{
-			TFGameRules()->HaveAllPlayersSpeakConceptIfAllowed( MP_CONCEPT_MVM_SENTRY_BUSTER_DOWN, FF_TEAM_PVE_DEFENDERS );
+			FFGameRules()->HaveAllPlayersSpeakConceptIfAllowed( MP_CONCEPT_MVM_SENTRY_BUSTER_DOWN, FF_TEAM_PVE_DEFENDERS );
 
 			// ACHIEVEMENT_TF_MVM_KILL_SENTRY_BUSTER
 			for ( int iDamager = 0 ; iDamager < MAX_ACHIEVEMENT_HISTORY_SLOTS ; iDamager ++ )

--- a/mp/src/game/server/ff/bot/behavior/scenario/capture_point/tf_bot_capture_point.cpp
+++ b/mp/src/game/server/ff/bot/behavior/scenario/capture_point/tf_bot_capture_point.cpp
@@ -38,7 +38,7 @@ ActionResult< CFFBot >	CFFBotCapturePoint::OnStart( CFFBot *me, Action< CFFBot >
 //---------------------------------------------------------------------------------------------
 ActionResult< CFFBot >	CFFBotCapturePoint::Update( CFFBot *me, float interval )
 {
-	if ( TFGameRules()->InSetup() )
+	if ( FFGameRules()->InSetup() )
 	{
 		// wait until the gates open, then path
 		m_path.Invalidate();
@@ -70,9 +70,9 @@ ActionResult< CFFBot >	CFFBotCapturePoint::Update( CFFBot *me, float interval )
 	bool isPushingToCapture = ( me->IsPointBeingCaptured( point ) && !me->IsInCombat() ) ||			// a friend is capturing
 							   me->IsCapturingPoint() ||												// we're capturing
 							   // me->m_Shared.InCond( TF_COND_INVULNERABLE ) ||						// we're ubered
-							   TFGameRules()->InOvertime() ||											// the game is in overtime
+							   FFGameRules()->InOvertime() ||											// the game is in overtime
 							   me->GetTimeLeftToCapture() < ff_bot_offense_must_push_time.GetFloat() ||	// nearly out of tim
-							   TFGameRules()->IsInTraining() ||											// teach newbies to capture
+							   FFGameRules()->IsInTraining() ||											// teach newbies to capture
 							   me->IsNearPoint( point );
 
 
@@ -127,7 +127,7 @@ ActionResult< CFFBot >	CFFBotCapturePoint::Update( CFFBot *me, float interval )
 			m_repathTimer.Start( RandomFloat( 2.0f, 3.0f ) ); 
 		}
 
-		if ( TFGameRules()->IsInTraining() && !me->IsAnyPointBeingCaptured() )
+		if ( FFGameRules()->IsInTraining() && !me->IsAnyPointBeingCaptured() )
 		{
 			// stop short of capturing until the human trainee starts it
 			if ( m_path.GetLength() < 1000.0f )

--- a/mp/src/game/server/ff/bot/behavior/scenario/capture_point/tf_bot_defend_point.cpp
+++ b/mp/src/game/server/ff/bot/behavior/scenario/capture_point/tf_bot_defend_point.cpp
@@ -93,7 +93,7 @@ bool CFFBotDefendPoint::IsPointThreatened( CFFBot *me )
 // Are we smart enough to get on the point to block the cap
 bool CFFBotDefendPoint::WillBlockCapture( CFFBot *me ) const
 {
-	if ( TFGameRules()->IsInTraining() )
+	if ( FFGameRules()->IsInTraining() )
 		return false;
 	
 	if ( me->IsDifficulty( CFFBot::EASY ) )
@@ -164,7 +164,7 @@ ActionResult< CFFBot >	CFFBotDefendPoint::Update( CFFBot *me, float interval )
 		return SuspendFor( new CFFBotSeekAndDestroy( 15.0f ), "Seek and destroy - we have lots of time" );
 	}
 
-	if ( TFGameRules()->InSetup() )
+	if ( FFGameRules()->InSetup() )
 	{
 		// don't lose patience during setup time
 		m_idleTimer.Reset();
@@ -331,7 +331,7 @@ public:
 	{
 		CTFNavArea *area = (CTFNavArea *)baseArea;
 
-		if ( !TFGameRules()->IsInKothMode() )
+		if ( !FFGameRules()->IsInKothMode() )
 		{
 			// don't select areas that are beyond the point
 			if ( area->GetIncursionDistance( m_myTeam ) > m_incursionFlowLimit )
@@ -354,7 +354,7 @@ public:
 
 	virtual bool ShouldSearch( CNavArea *adjArea, CNavArea *currentArea, float travelDistanceSoFar )
 	{
-		if ( adjArea->IsBlocked( TFGameRules()->IsInKothMode() ? TEAM_ANY : m_myTeam ) )
+		if ( adjArea->IsBlocked( FFGameRules()->IsInKothMode() ? TEAM_ANY : m_myTeam ) )
 		{
 			return false;
 		}
@@ -395,7 +395,7 @@ CTFNavArea *CFFBotDefendPoint::SelectAreaToDefendFrom( CFFBot *me )
 	CUtlVector< CTFNavArea * > defenseAreas;
 
 /*
-	if ( !TFGameRules()->IsInKothMode() &&
+	if ( !FFGameRules()->IsInKothMode() &&
 		 point->GetTeamCapPercentage( me->GetTeamNumber() ) <= 0.0f &&	// point is currently safe
 		 ( ObjectiveResource()->GetPreviousPointForPoint( point->GetPointIndex(), me->GetTeamNumber(), 0 ) < 0 ||		 // this is the first cap point
 			me->IsPlayerClass( CLASS_PYRO ) ) )						// pyros are skirmishers

--- a/mp/src/game/server/ff/bot/behavior/scenario/capture_the_flag/tf_bot_attack_flag_defenders.cpp
+++ b/mp/src/game/server/ff/bot/behavior/scenario/capture_the_flag/tf_bot_attack_flag_defenders.cpp
@@ -62,7 +62,7 @@ ActionResult< CFFBot > CFFBotAttackFlagDefenders::Update( CFFBot *me, float inte
 		}
 
 		// can't reach flag if it is at home
-		if ( !TFGameRules()->IsMannVsMachineMode() || !flag->IsHome() )
+		if ( !FFGameRules()->IsMannVsMachineMode() || !flag->IsHome() )
 		{
 			CFFPlayer *carrier = ToFFPlayer( flag->GetOwnerEntity() );
 			if ( !carrier )
@@ -115,7 +115,7 @@ ActionResult< CFFBot > CFFBotAttackFlagDefenders::Update( CFFBot *me, float inte
 			m_repathTimer.Start( RandomFloat( 1.0f, 3.0f ) );
 
 			CFFBotPathCost cost( me, DEFAULT_ROUTE );
-			float maxPathLength = TFGameRules()->IsMannVsMachineMode() ? TFBOT_MVM_MAX_PATH_LENGTH : 0.0f;
+			float maxPathLength = FFGameRules()->IsMannVsMachineMode() ? TFBOT_MVM_MAX_PATH_LENGTH : 0.0f;
 			m_path.Compute( me, m_chasePlayer, cost, maxPathLength );
 		}
 

--- a/mp/src/game/server/ff/bot/behavior/scenario/capture_the_flag/tf_bot_deliver_flag.cpp
+++ b/mp/src/game/server/ff/bot/behavior/scenario/capture_the_flag/tf_bot_deliver_flag.cpp
@@ -74,7 +74,7 @@ ActionResult< CFFBot >	CFFBotDeliverFlag::OnStart( CFFBot *me, Action< CFFBot > 
 // In Mann Vs Machine, the flag carrier gets stronger the longer he carries the flag
 bool CFFBotDeliverFlag::UpgradeOverTime( CFFBot *me )
 {
-	if ( TFGameRules()->IsMannVsMachineMode() && m_upgradeLevel != DONT_UPGRADE )
+	if ( FFGameRules()->IsMannVsMachineMode() && m_upgradeLevel != DONT_UPGRADE )
 	{
 		CTFNavArea *myArea = me->GetLastKnownArea();
 		int spawnRoomFlag = me->GetTeamNumber() == FF_TEAM_RED ? TF_NAV_SPAWN_ROOM_RED : TF_NAV_SPAWN_ROOM_BLUE;
@@ -115,7 +115,7 @@ bool CFFBotDeliverFlag::UpgradeOverTime( CFFBot *me )
 			{
 				++m_upgradeLevel;
 				
-				TFGameRules()->BroadcastSound( 255, "MVM.Warning" );
+				FFGameRules()->BroadcastSound( 255, "MVM.Warning" );
 
 				switch( m_upgradeLevel )
 				{
@@ -131,7 +131,7 @@ bool CFFBotDeliverFlag::UpgradeOverTime( CFFBot *me )
 						TFObjectiveResource()->SetFlagCarrierUpgradeLevel( 1 );
 						TFObjectiveResource()->SetBaseMvMBombUpgradeTime( gpGlobals->curtime );
 						TFObjectiveResource()->SetNextMvMBombUpgradeTime( gpGlobals->curtime + m_upgradeTimer.GetRemainingTime() );
-						TFGameRules()->HaveAllPlayersSpeakConceptIfAllowed( MP_CONCEPT_MVM_BOMB_CARRIER_UPGRADE1, FF_TEAM_PVE_DEFENDERS );
+						FFGameRules()->HaveAllPlayersSpeakConceptIfAllowed( MP_CONCEPT_MVM_BOMB_CARRIER_UPGRADE1, FF_TEAM_PVE_DEFENDERS );
 						DispatchParticleEffect( "mvm_levelup1", PATTACH_POINT_FOLLOW, me, "head" );
 					}
 					return true;
@@ -162,7 +162,7 @@ bool CFFBotDeliverFlag::UpgradeOverTime( CFFBot *me )
 						TFObjectiveResource()->SetFlagCarrierUpgradeLevel( 2 );
 						TFObjectiveResource()->SetBaseMvMBombUpgradeTime( gpGlobals->curtime );
 						TFObjectiveResource()->SetNextMvMBombUpgradeTime( gpGlobals->curtime + m_upgradeTimer.GetRemainingTime() );
-						TFGameRules()->HaveAllPlayersSpeakConceptIfAllowed( MP_CONCEPT_MVM_BOMB_CARRIER_UPGRADE2, FF_TEAM_PVE_DEFENDERS );
+						FFGameRules()->HaveAllPlayersSpeakConceptIfAllowed( MP_CONCEPT_MVM_BOMB_CARRIER_UPGRADE2, FF_TEAM_PVE_DEFENDERS );
 						DispatchParticleEffect( "mvm_levelup2", PATTACH_POINT_FOLLOW, me, "head" );
 					}
 					return true;
@@ -179,7 +179,7 @@ bool CFFBotDeliverFlag::UpgradeOverTime( CFFBot *me )
 						TFObjectiveResource()->SetFlagCarrierUpgradeLevel( 3 );
 						TFObjectiveResource()->SetBaseMvMBombUpgradeTime( -1 );
 						TFObjectiveResource()->SetNextMvMBombUpgradeTime( -1 );
-						TFGameRules()->HaveAllPlayersSpeakConceptIfAllowed( MP_CONCEPT_MVM_BOMB_CARRIER_UPGRADE3, FF_TEAM_PVE_DEFENDERS );
+						FFGameRules()->HaveAllPlayersSpeakConceptIfAllowed( MP_CONCEPT_MVM_BOMB_CARRIER_UPGRADE3, FF_TEAM_PVE_DEFENDERS );
 						DispatchParticleEffect( "mvm_levelup3", PATTACH_POINT_FOLLOW, me, "head" );
 					}
 					return true;
@@ -208,7 +208,7 @@ ActionResult< CFFBot > CFFBotDeliverFlag::Update( CFFBot *me, float interval )
 		return Done( "I'm no longer carrying the flag" );
 	}
 
-	if ( TFGameRules()->IsMannVsMachineMode() )
+	if ( FFGameRules()->IsMannVsMachineMode() )
 	{
 		// let the bomb carrier use it's buff banners/etc
 		Action< CFFBot > *result = me->OpportunisticallyUseWeaponAbilities();
@@ -244,7 +244,7 @@ ActionResult< CFFBot > CFFBotDeliverFlag::Update( CFFBot *me, float interval )
 
 		if ( flOldTravelDistance != -1.0f && m_flTotalTravelDistance - flOldTravelDistance > 2000.0f )
 		{
-			TFGameRules()->BroadcastSound( 255, "Announcer.MVM_Bomb_Reset" );
+			FFGameRules()->BroadcastSound( 255, "Announcer.MVM_Bomb_Reset" );
 
 			// Look for players that helped with the reset and send an event
 			CUtlVector<CFFPlayer *> playerVector;
@@ -288,7 +288,7 @@ void CFFBotDeliverFlag::OnEnd( CFFBot *me, Action< CFFBot > *nextAction )
 {
 	me->ClearAttribute( CFFBot::SUPPRESS_FIRE );
 
-	if ( TFGameRules() && TFGameRules()->IsMannVsMachineMode() )
+	if ( FFGameRules() && FFGameRules()->IsMannVsMachineMode() )
 	{
 		me->m_Shared.ResetRageBuffs();
 	}
@@ -326,7 +326,7 @@ QueryResultType	CFFBotDeliverFlag::ShouldRetreat( const INextBot *me ) const
 //---------------------------------------------------------------------------------------------
 EventDesiredResult< CFFBot > CFFBotDeliverFlag::OnContact( CFFBot *me, CBaseEntity *other, CGameTrace *result )
 {
-	if ( TFGameRules()->IsMannVsMachineMode() && other && FClassnameIs( other, "func_capturezone" ) )
+	if ( FFGameRules()->IsMannVsMachineMode() && other && FClassnameIs( other, "func_capturezone" ) )
 	{
 		return TrySuspendFor( new CFFBotMvMDeployBomb, RESULT_CRITICAL, "Delivering the bomb!" );
 	}

--- a/mp/src/game/server/ff/bot/behavior/scenario/capture_the_flag/tf_bot_fetch_flag.cpp
+++ b/mp/src/game/server/ff/bot/behavior/scenario/capture_the_flag/tf_bot_fetch_flag.cpp
@@ -35,7 +35,7 @@ ActionResult< CFFBot > CFFBotFetchFlag::Update( CFFBot *me, float interval )
 
 	if ( !flag )
 	{
-		if ( TFGameRules()->IsMannVsMachineMode() )
+		if ( FFGameRules()->IsMannVsMachineMode() )
 		{
 			return SuspendFor( new CFFBotAttackFlagDefenders, "Flag flag exists - Attacking the enemy flag defenders" );
 		}
@@ -45,7 +45,7 @@ ActionResult< CFFBot > CFFBotFetchFlag::Update( CFFBot *me, float interval )
 
 
 
-	if ( TFGameRules()->IsMannVsMachineMode() && flag->IsHome() )
+	if ( FFGameRules()->IsMannVsMachineMode() && flag->IsHome() )
 	{
 		if ( gpGlobals->curtime - me->GetSpawnTime() < 1.0f && me->GetTeamNumber() != TEAM_SPECTATOR )
 		{
@@ -86,7 +86,7 @@ ActionResult< CFFBot > CFFBotFetchFlag::Update( CFFBot *me, float interval )
 	if ( m_repathTimer.IsElapsed() )
 	{
 		CFFBotPathCost cost( me, DEFAULT_ROUTE );
-		float maxPathLength = TFGameRules()->IsMannVsMachineMode() ? TFBOT_MVM_MAX_PATH_LENGTH : 0.0f;
+		float maxPathLength = FFGameRules()->IsMannVsMachineMode() ? TFBOT_MVM_MAX_PATH_LENGTH : 0.0f;
 		if ( m_path.Compute( me, flag->WorldSpaceCenter(), cost, maxPathLength ) == false )
 		{
 			if ( flag->IsDropped() )

--- a/mp/src/game/server/ff/bot/behavior/scenario/creep_wave/tf_bot_creep_wave.cpp
+++ b/mp/src/game/server/ff/bot/behavior/scenario/creep_wave/tf_bot_creep_wave.cpp
@@ -5,7 +5,7 @@
 
 #include "cbase.h"
 
-#ifdef TF_CREEP_MODE
+#ifdef FF_CREEP_MODE
 
 #include "team.h"
 #include "team_control_point_master.h"
@@ -83,7 +83,7 @@ ActionResult< CFFBot > CFFBotCreepWave::Update( CFFBot *me, float interval )
 	}
 
 	CUtlVector< CTeamControlPoint * > captureVector;
-	TFGameRules()->CollectCapturePoints( me, &captureVector );
+	FFGameRules()->CollectCapturePoints( me, &captureVector );
 
 	if ( captureVector.Count() == 0 )
 	{
@@ -237,4 +237,4 @@ ActionResult< CFFBot > CFFBotCreepAttack::Update( CFFBot *me, float interval )
 
 
 
-#endif // TF_CREEP_MODE
+#endif // FF_CREEP_MODE

--- a/mp/src/game/server/ff/bot/behavior/scenario/raid/tf_bot_squad_attack.cpp
+++ b/mp/src/game/server/ff/bot/behavior/scenario/raid/tf_bot_squad_attack.cpp
@@ -76,7 +76,7 @@ ActionResult< CFFBot > CFFBotSquadAttack::Update( CFFBot *me, float interval )
 	{
 		m_victimConsiderTimer.Start( 3.0f );
 
-		m_victim = TFGameRules()->GetRaidLogic()->SelectRaiderToAttack();
+		m_victim = FFGameRules()->GetRaidLogic()->SelectRaiderToAttack();
 	}
 
 	if ( m_victim )

--- a/mp/src/game/server/ff/bot/behavior/scenario/raid/tf_bot_wander.cpp
+++ b/mp/src/game/server/ff/bot/behavior/scenario/raid/tf_bot_wander.cpp
@@ -53,7 +53,7 @@ ActionResult< CFFBot >	CFFBotWander::Update( CFFBot *me, float interval )
 	if ( me->HasAttribute( CFFBot::AGGRESSIVE ) )
 	{
 		// I'm a mob rusher - pick a random raider and attack them!
-		CFFPlayer *victim = TFGameRules()->GetRaidLogic()->SelectRaiderToAttack();
+		CFFPlayer *victim = FFGameRules()->GetRaidLogic()->SelectRaiderToAttack();
 		if ( victim )
 		{
 			return SuspendFor( new CFFBotMobRush( victim ), "Rushing a raider" );

--- a/mp/src/game/server/ff/bot/behavior/sniper/tf_bot_sniper_attack.cpp
+++ b/mp/src/game/server/ff/bot/behavior/sniper/tf_bot_sniper_attack.cpp
@@ -209,7 +209,7 @@ bool CFFBotSniperAttack::IsImmediateThreat( const CBaseCombatCharacter *subject,
 	}
 
 #ifdef TF_RAID_MODE
-	if ( !TFGameRules()->IsRaidMode() )
+	if ( !FFGameRules()->IsRaidMode() )
 	{
 	}
 	else

--- a/mp/src/game/server/ff/bot/behavior/sniper/tf_bot_sniper_lurk.cpp
+++ b/mp/src/game/server/ff/bot/behavior/sniper/tf_bot_sniper_lurk.cpp
@@ -65,7 +65,7 @@ ActionResult< CFFBot >	CFFBotSniperLurk::OnStart( CFFBot *me, Action< CFFBot > *
 
 	m_priorHint = NULL;
 
-	if ( TFGameRules()->IsMannVsMachineMode() && me->GetTeamNumber() == FF_TEAM_PVE_INVADERS )
+	if ( FFGameRules()->IsMannVsMachineMode() && me->GetTeamNumber() == FF_TEAM_PVE_INVADERS )
 	{
 		// mann vs machine snipers shouldn't stop until they reach their home
 		//m_isOpportunistic = false;
@@ -84,7 +84,7 @@ ActionResult< CFFBot >	CFFBotSniperLurk::OnStart( CFFBot *me, Action< CFFBot > *
 ActionResult< CFFBot >	CFFBotSniperLurk::Update( CFFBot *me, float interval )
 {
 #ifdef TF_RAID_MODE
-	if ( TFGameRules()->IsRaidMode() )
+	if ( FFGameRules()->IsRaidMode() )
 	{
 	}
 	else
@@ -442,7 +442,7 @@ bool CFFBotSniperLurk::FindNewHome( CFFBot *me )
 
 
 #ifdef TF_RAID_MODE
-	if ( TFGameRules()->IsRaidMode() )
+	if ( FFGameRules()->IsRaidMode() )
 	{
 		// stay put for now
 		return true;
@@ -509,7 +509,7 @@ QueryResultType CFFBotSniperLurk::ShouldAttack( const INextBot *bot, const CKnow
 
 	CTFNavArea *area = me->GetLastKnownArea();
 
-	if ( TFGameRules()->IsMannVsMachineMode() && area && area->HasAttributeTF( TF_NAV_SPAWN_ROOM_BLUE ) )
+	if ( FFGameRules()->IsMannVsMachineMode() && area && area->HasAttributeTF( TF_NAV_SPAWN_ROOM_BLUE ) )
 	{
 		// don't fire while in the spawn area
 		return ANSWER_NO;
@@ -523,7 +523,7 @@ QueryResultType CFFBotSniperLurk::ShouldAttack( const INextBot *bot, const CKnow
 //---------------------------------------------------------------------------------------------
 QueryResultType CFFBotSniperLurk::ShouldRetreat( const INextBot *me ) const
 {
-	if ( TFGameRules()->IsMannVsMachineMode() && me->GetEntity()->GetTeamNumber() == FF_TEAM_PVE_INVADERS )
+	if ( FFGameRules()->IsMannVsMachineMode() && me->GetEntity()->GetTeamNumber() == FF_TEAM_PVE_INVADERS )
 	{
 		return ANSWER_NO;
 	}
@@ -538,7 +538,7 @@ const CKnownEntity *CFFBotSniperLurk::SelectMoreDangerousThreat( const INextBot 
 																 const CKnownEntity *threat1, 
 																 const CKnownEntity *threat2 ) const
 {
-	if ( TFGameRules()->IsMannVsMachineMode() && ff_mvm_bot_sniper_target_by_dps.GetBool() )
+	if ( FFGameRules()->IsMannVsMachineMode() && ff_mvm_bot_sniper_target_by_dps.GetBool() )
 	{
 		CFFBot *me = ToTFBot( meBot->GetEntity() );
 

--- a/mp/src/game/server/ff/bot/behavior/spy/tf_bot_spy_attack.cpp
+++ b/mp/src/game/server/ff/bot/behavior/spy/tf_bot_spy_attack.cpp
@@ -125,7 +125,7 @@ ActionResult< CFFBot >	CFFBotSpyAttack::Update( CFFBot *me, float interval )
 	case CFFBot::EXPERT:	behindTolerance = 0.0f;		break;
 	}
 
-	if ( TFGameRules()->IsMannVsMachineMode() )
+	if ( FFGameRules()->IsMannVsMachineMode() )
 	{
 		behindTolerance = 0.7071f;
 	}
@@ -201,7 +201,7 @@ ActionResult< CFFBot >	CFFBotSpyAttack::Update( CFFBot *me, float interval )
 						isMovingTowardVictim = false;
 					}
 				}
-				else if ( TFGameRules()->IsMannVsMachineMode() )
+				else if ( FFGameRules()->IsMannVsMachineMode() )
 				{
 					if ( m_chuckleTimer.IsElapsed() )
 					{

--- a/mp/src/game/server/ff/bot/behavior/spy/tf_bot_spy_infiltrate.cpp
+++ b/mp/src/game/server/ff/bot/behavior/spy/tf_bot_spy_infiltrate.cpp
@@ -82,7 +82,7 @@ ActionResult< CFFBot >	CFFBotSpyInfiltrate::Update( CFFBot *me, float interval )
 		m_findHidingSpotTimer.Start( 3.0f );
 	}
 
-	if ( !TFGameRules()->InSetup() )
+	if ( !FFGameRules()->InSetup() )
 	{
 		// go after victims we've gotten behind
 		if ( threat && threat->GetTimeSinceLastKnown() < 3.0f )
@@ -114,7 +114,7 @@ ActionResult< CFFBot >	CFFBotSpyInfiltrate::Update( CFFBot *me, float interval )
 		if ( myArea == m_hideArea )
 		{
 			// stay hidden during setup time
-			if ( TFGameRules()->InSetup() )
+			if ( FFGameRules()->InSetup() )
 			{
 				m_waitTimer.Start( RandomFloat( 0.0f, 5.0f ) );
 			}
@@ -183,7 +183,7 @@ bool CFFBotSpyInfiltrate::FindHidingSpot( CFFBot *me )
 {
 	m_hideArea = NULL;
 
-	if ( me->GetAliveDuration() < 5.0f && TFGameRules()->InSetup() )
+	if ( me->GetAliveDuration() < 5.0f && FFGameRules()->InSetup() )
 	{
 		// wait a bit until the nav mesh has updated itself
 		return false;
@@ -193,7 +193,7 @@ bool CFFBotSpyInfiltrate::FindHidingSpot( CFFBot *me )
 	const CUtlVector< CTFNavArea * > *enemySpawnExitVector = TheTFNavMesh()->GetSpawnRoomExitAreas( GetEnemyTeam( myTeam ) );
 
 #ifdef TF_RAID_MODE
-	if ( TFGameRules()->IsRaidMode() )
+	if ( FFGameRules()->IsRaidMode() )
 	{
 		// for now, just lurk where we are
 		return false;

--- a/mp/src/game/server/ff/bot/behavior/squad/tf_bot_escort_squad_leader.cpp
+++ b/mp/src/game/server/ff/bot/behavior/squad/tf_bot_escort_squad_leader.cpp
@@ -73,7 +73,7 @@ ActionResult< CFFBot > CFFBotEscortSquadLeader::Update( CFFBot *me, float interv
 		return Done( "Squad leader is dead" );
 	}
 
-	if ( TFGameRules() && TFGameRules()->IsMannVsMachineMode() && leader == me )
+	if ( FFGameRules() && FFGameRules()->IsMannVsMachineMode() && leader == me )
 	{
 		const char* pszNowLeader = "I'm now the squad leader! Going for the flag!";
 		if ( me->HasAttribute( CFFBot::AGGRESSIVE ) )

--- a/mp/src/game/server/ff/bot/behavior/tf_bot_attack.cpp
+++ b/mp/src/game/server/ff/bot/behavior/tf_bot_attack.cpp
@@ -67,7 +67,7 @@ ActionResult< CFFBot >	CFFBotAttack::Update( CFFBot *me, float interval )
 	{
 		if ( threat->IsVisibleRecently() )
 		{
-			if ( isUsingCloseRangeWeapon && !TFGameRules()->IsMannVsMachineMode() )	// all bots in MvM use the default route
+			if ( isUsingCloseRangeWeapon && !FFGameRules()->IsMannVsMachineMode() )	// all bots in MvM use the default route
 			{
 				CFFBotPathCost cost( me, SAFEST_ROUTE );
 				m_chasePath.Update( me, threat->GetEntity(), cost );
@@ -102,7 +102,7 @@ ActionResult< CFFBot >	CFFBotAttack::Update( CFFBot *me, float interval )
 				//m_repathTimer.Start( RandomFloat( 0.3f, 0.5f ) );
 				m_repathTimer.Start( RandomFloat( 3.0f, 5.0f ) );
 
-				if ( isUsingCloseRangeWeapon && !TFGameRules()->IsMannVsMachineMode() )	// all bots in MvM use the default route
+				if ( isUsingCloseRangeWeapon && !FFGameRules()->IsMannVsMachineMode() )	// all bots in MvM use the default route
 				{
 					CFFBotPathCost cost( me, SAFEST_ROUTE );
 					m_path.Compute( me, threat->GetLastKnownPosition(), cost );
@@ -110,7 +110,7 @@ ActionResult< CFFBot >	CFFBotAttack::Update( CFFBot *me, float interval )
 				else
 				{
 					CFFBotPathCost cost( me, DEFAULT_ROUTE );
-					float maxPathLength = TFGameRules()->IsMannVsMachineMode() ? TFBOT_MVM_MAX_PATH_LENGTH : 0.0f;
+					float maxPathLength = FFGameRules()->IsMannVsMachineMode() ? TFBOT_MVM_MAX_PATH_LENGTH : 0.0f;
 					m_path.Compute( me, threat->GetLastKnownPosition(), cost, maxPathLength );
 				}
 			}

--- a/mp/src/game/server/ff/bot/behavior/tf_bot_behavior.cpp
+++ b/mp/src/game/server/ff/bot/behavior/tf_bot_behavior.cpp
@@ -84,12 +84,12 @@ ActionResult< CFFBot >	CFFBotMainAction::OnStart( CFFBot *me, Action< CFFBot > *
 		return ChangeTo( new CFFBotDead, "I'm actually dead" );
 	}
 
-#ifdef TF_CREEP_MODE
-	if ( TFGameRules()->IsCreepWaveMode() )
+#ifdef FF_CREEP_MODE
+	if ( FFGameRules()->IsCreepWaveMode() )
 	{
 		return ChangeTo( new CFFBotCreepWave, "I'm a creep" );
 	}
-#endif // TF_CREEP_MODE
+#endif // FF_CREEP_MODE
 
 
 #ifdef STAGING_ONLY
@@ -130,7 +130,7 @@ ActionResult< CFFBot >	CFFBotMainAction::Update( CFFBot *me, float interval )
 	me->GetVisionInterface()->SetFieldOfView( me->GetFOV() );
 
 	// teammates in training have infinite ammo
-	if ( TFGameRules()->IsInTraining() && me->GetTeamNumber() == FF_TEAM_BLUE )
+	if ( FFGameRules()->IsInTraining() && me->GetTeamNumber() == FF_TEAM_BLUE )
 	{
 		me->GiveAmmo( 1000, TF_AMMO_METAL, true );
 	}
@@ -160,7 +160,7 @@ ActionResult< CFFBot >	CFFBotMainAction::Update( CFFBot *me, float interval )
 // 		}
 	}
 
-	if ( TFGameRules()->IsMannVsMachineMode() && me->GetTeamNumber() == FF_TEAM_PVE_INVADERS )
+	if ( FFGameRules()->IsMannVsMachineMode() && me->GetTeamNumber() == FF_TEAM_PVE_INVADERS )
 	{
 		// infinite ammo
 		// me->GiveAmmo( 100, TF_AMMO_PRIMARY, true );
@@ -370,7 +370,7 @@ EventDesiredResult< CFFBot > CFFBotMainAction::OnContact( CFFBot *me, CBaseEntit
 		m_lastTouchTime = gpGlobals->curtime;
 
 		// Mini-bosses destroy non-Sentrygun objects they bump into (ie: Dispensers)
-		if ( TFGameRules()->IsMannVsMachineMode() && me->IsMiniBoss() )
+		if ( FFGameRules()->IsMannVsMachineMode() && me->IsMiniBoss() )
 		{
 			if ( other->IsBaseObject() )
 			{
@@ -436,7 +436,7 @@ EventDesiredResult< CFFBot > CFFBotMainAction::OnStuck( CFFBot *me )
 	}
 */
 
-	if ( TFGameRules()->IsMannVsMachineMode() )
+	if ( FFGameRules()->IsMannVsMachineMode() )
 	{
 		if ( me->m_Shared.InCond( TF_COND_MVM_BOT_STUN_RADIOWAVE ) )
 		{
@@ -542,7 +542,7 @@ EventDesiredResult< CFFBot > CFFBotMainAction::OnOtherKilled( CFFBot *me, CBaseC
 		{
 			bool isTaunting = !me->HasTheFlag() && RandomFloat( 0.0f, 100.0f ) <= ff_bot_taunt_victim_chance.GetFloat();
 
-			if ( TFGameRules()->IsMannVsMachineMode() && me->IsMiniBoss() )
+			if ( FFGameRules()->IsMannVsMachineMode() && me->IsMiniBoss() )
 			{
 				// Bosses don't taunt puny humans
 				isTaunting = false;
@@ -1045,7 +1045,7 @@ const CKnownEntity *CFFBotMainAction::SelectMoreDangerousThreatInternal( const I
 	// close range sentries are the most dangerous of all
 	bool shouldFearSentryGuns = true;
 
-	if ( TFGameRules()->IsMannVsMachineMode() )
+	if ( FFGameRules()->IsMannVsMachineMode() )
 	{
 		// MvM bots are not afraid of sentry guns and treat them like other enemy players
 		shouldFearSentryGuns = false;
@@ -1086,7 +1086,7 @@ const CKnownEntity *CFFBotMainAction::SelectMoreDangerousThreatInternal( const I
 	}
 
 	// enforce Spy hatred in MvM mode
-	if ( TFGameRules()->IsMannVsMachineMode() )
+	if ( FFGameRules()->IsMannVsMachineMode() )
 	{
 		const float spyHateRadius = 1000.0f;
 
@@ -1278,7 +1278,7 @@ void CFFBotMainAction::FireWeaponAtEnemy( CFFBot *me )
 	}
 
 	// if our target is uber'd, most weapons are useless - unless we're in MvM, where invuln tanking is valuable
-	if ( TFGameRules() && !TFGameRules()->IsMannVsMachineMode() )
+	if ( FFGameRules() && !FFGameRules()->IsMannVsMachineMode() )
 	{
 		CFFPlayer *playerThreat = ToFFPlayer( threat->GetEntity() );
 		if ( playerThreat && playerThreat->m_Shared.IsInvulnerable() )
@@ -1297,7 +1297,7 @@ void CFFBotMainAction::FireWeaponAtEnemy( CFFBot *me )
 	if ( me->GetIntentionInterface()->ShouldAttack( me, threat ) == ANSWER_NO )
 		return;
 
-	if ( TFGameRules()->InSetup() )
+	if ( FFGameRules()->InSetup() )
 	{
 		// wait until the gates open
 		return;
@@ -1313,7 +1313,7 @@ void CFFBotMainAction::FireWeaponAtEnemy( CFFBot *me )
 	}
 
 	// limit range of hitscan weapon fire in MvM
-	if ( TFGameRules()->IsMannVsMachineMode() && !me->IsPlayerClass( CLASS_SNIPER ) && me->IsHitScanWeapon( myWeapon ) )
+	if ( FFGameRules()->IsMannVsMachineMode() && !me->IsPlayerClass( CLASS_SNIPER ) && me->IsHitScanWeapon( myWeapon ) )
 	{
 		if ( me->IsRangeGreaterThan( threat->GetEntity(), ff_bot_hitscan_range_limit.GetFloat() ) )
 		{
@@ -1358,7 +1358,7 @@ void CFFBotMainAction::FireWeaponAtEnemy( CFFBot *me )
 			// only fire if zoomed in
 			if ( me->m_Shared.InCond( TF_COND_ZOOMED ) )
 			{
-				const float reactionTime = TFGameRules()->IsMannVsMachineMode() ? 0.5f : 0.1f;	// just a moment to stop headshots when obviously panning too fast to see
+				const float reactionTime = FFGameRules()->IsMannVsMachineMode() ? 0.5f : 0.1f;	// just a moment to stop headshots when obviously panning too fast to see
 				if ( m_steadyTimer.HasStarted() && m_steadyTimer.IsGreaterThen( reactionTime ) )
 				{
 					trace_t trace;
@@ -1494,7 +1494,7 @@ QueryResultType	CFFBotMainAction::ShouldRetreat( const INextBot *bot ) const
 		return ANSWER_YES;
 
 	// don't retreat during setup time, since we're always safe
-	if ( TFGameRules()->InSetup() )
+	if ( FFGameRules()->InSetup() )
 		return ANSWER_NO;
 
 
@@ -1546,7 +1546,7 @@ void CFFBotMainAction::Dodge( CFFBot *me )
 
 
 #ifdef TF_RAID_MODE
-	if ( TFGameRules()->IsRaidMode() )
+	if ( FFGameRules()->IsRaidMode() )
 		return;
 #endif // TF_RAID_MODE
 

--- a/mp/src/game/server/ff/bot/behavior/tf_bot_dead.cpp
+++ b/mp/src/game/server/ff/bot/behavior/tf_bot_dead.cpp
@@ -46,7 +46,7 @@ ActionResult< CFFBot >	CFFBotDead::Update( CFFBot *me, float interval )
 	}
 
 #ifdef TF_RAID_MODE
-	if ( TFGameRules()->IsRaidMode() && me->GetTeamNumber() == FF_TEAM_RED )
+	if ( FFGameRules()->IsRaidMode() && me->GetTeamNumber() == FF_TEAM_RED )
 	{
 		// dead defenders go to spectator for recycling
 		me->ChangeTeam( TEAM_SPECTATOR, false, true );

--- a/mp/src/game/server/ff/bot/behavior/tf_bot_destroy_enemy_sentry.cpp
+++ b/mp/src/game/server/ff/bot/behavior/tf_bot_destroy_enemy_sentry.cpp
@@ -181,7 +181,7 @@ bool CFFBotDestroyEnemySentry::IsPossible( CFFBot *me )
 	}
 
 #ifdef TF_RAID_MODE
-	if ( TFGameRules()->IsRaidMode() )
+	if ( FFGameRules()->IsRaidMode() )
 	{
 		if ( me->GetTeamNumber() == FF_TEAM_PVE_INVADERS )
 		{
@@ -190,7 +190,7 @@ bool CFFBotDestroyEnemySentry::IsPossible( CFFBot *me )
 	}
 #endif
 
-	if ( TFGameRules()->IsMannVsMachineMode() )
+	if ( FFGameRules()->IsMannVsMachineMode() )
 	{
 		if ( me->GetTeamNumber() == FF_TEAM_PVE_INVADERS )
 		{
@@ -653,7 +653,7 @@ ActionResult< CFFBot >	CFFBotDestroyEnemySentry::Update( CFFBot *me, float inter
 
 		if ( me->IsRangeLessThan( attackSpot, 200.0f ) )
 		{
-#ifdef TF_CREEP_MODE
+#ifdef FF_CREEP_MODE
 			if ( m_creepTimer.IsElapsed() )
 			{
 				m_canMove = !m_canMove;

--- a/mp/src/game/server/ff/bot/behavior/tf_bot_get_ammo.cpp
+++ b/mp/src/game/server/ff/bot/behavior/tf_bot_get_ammo.cpp
@@ -126,7 +126,7 @@ bool CFFBotGetAmmo::IsPossible( CFFBot *me )
 
 	CAmmoFilter ammoFilter( me );
 
-	const CUtlVector< CHandle< CBaseEntity > > &staticAmmoVector = TFGameRules()->GetAmmoEntityVector();
+	const CUtlVector< CHandle< CBaseEntity > > &staticAmmoVector = FFGameRules()->GetAmmoEntityVector();
 	CBaseEntity *closestAmmo = NULL;
 	float closestAmmoTravelDistance = FLT_MAX;
 

--- a/mp/src/game/server/ff/bot/behavior/tf_bot_get_health.cpp
+++ b/mp/src/game/server/ff/bot/behavior/tf_bot_get_health.cpp
@@ -110,13 +110,13 @@ bool CFFBotGetHealth::IsPossible( CFFBot *me )
 
 #ifdef TF_RAID_MODE
 	// mobs don't heal
-	if ( TFGameRules()->IsRaidMode() && me->HasAttribute( CFFBot::AGGRESSIVE ) )
+	if ( FFGameRules()->IsRaidMode() && me->HasAttribute( CFFBot::AGGRESSIVE ) )
 	{
 		return false;
 	}
 #endif // TF_RAID_MODE
 
-	if ( TFGameRules()->IsMannVsMachineMode() )
+	if ( FFGameRules()->IsMannVsMachineMode() )
 	{
 		return false;
 	}
@@ -134,7 +134,7 @@ bool CFFBotGetHealth::IsPossible( CFFBot *me )
 	CUtlVector< CHandle< CBaseEntity > > healthVector;
 	CHealthFilter healthFilter( me );
 
-	me->SelectReachableObjects( TFGameRules()->GetHealthEntityVector(), &healthVector, healthFilter, me->GetLastKnownArea(), searchRange );
+	me->SelectReachableObjects( FFGameRules()->GetHealthEntityVector(), &healthVector, healthFilter, me->GetLastKnownArea(), searchRange );
 
 	if ( healthVector.Count() == 0 )
 	{

--- a/mp/src/game/server/ff/bot/behavior/tf_bot_mvm_deploy_bomb.cpp
+++ b/mp/src/game/server/ff/bot/behavior/tf_bot_mvm_deploy_bomb.cpp
@@ -108,7 +108,7 @@ ActionResult< CFFBot > CFFBotMvMDeployBomb::Update( CFFBot *me, float interval )
 			const char *pszSoundName = me->IsMiniBoss() ? "MVM.DeployBombGiant" : "MVM.DeployBombSmall";
 			me->EmitSound( pszSoundName );
 
-			TFGameRules()->PlayThrottledAlert( 255, "Announcer.MVM_Bomb_Alert_Deploying", 5.0f );
+			FFGameRules()->PlayThrottledAlert( 255, "Announcer.MVM_Bomb_Alert_Deploying", 5.0f );
 		}
 		break;
 
@@ -121,7 +121,7 @@ ActionResult< CFFBot > CFFBotMvMDeployBomb::Update( CFFBot *me, float interval )
 			}
 
 			m_timer.Start( 2.0f );
-			TFGameRules()->BroadcastSound( 255, "Announcer.MVM_Robots_Planted" );
+			FFGameRules()->BroadcastSound( 255, "Announcer.MVM_Robots_Planted" );
 			me->SetDeployingBombState( TF_BOMB_DEPLOYING_COMPLETE );
 			me->m_takedamage = DAMAGE_NO;
 			me->AddEffects( EF_NODRAW );

--- a/mp/src/game/server/ff/bot/behavior/tf_bot_scenario_monitor.cpp
+++ b/mp/src/game/server/ff/bot/behavior/tf_bot_scenario_monitor.cpp
@@ -115,7 +115,7 @@ Action< CFFBot > *CFFBotScenarioMonitor::DesiredScenarioAndClassAction( CFFBot *
 #endif // TF_RAID_MODE
 
 #ifdef TF_RAID_MODE
-	if ( TFGameRules()->IsBossBattleMode() )
+	if ( FFGameRules()->IsBossBattleMode() )
 	{
 		if ( me->GetTeamNumber() == FF_TEAM_BLUE )
 		{
@@ -143,9 +143,9 @@ Action< CFFBot > *CFFBotScenarioMonitor::DesiredScenarioAndClassAction( CFFBot *
 			return new CFFBotEngineerBuild;
 		}
 
-		return new CFFBotEscort( TFGameRules()->GetActiveBoss() );
+		return new CFFBotEscort( FFGameRules()->GetActiveBoss() );
 	}
-	else if ( TFGameRules()->IsRaidMode() )
+	else if ( FFGameRules()->IsRaidMode() )
 	{
 		if ( me->GetTeamNumber() == FF_TEAM_BLUE )
 		{
@@ -178,7 +178,7 @@ Action< CFFBot > *CFFBotScenarioMonitor::DesiredScenarioAndClassAction( CFFBot *
 	}
 #endif // TF_RAID_MODE	
 
-	if ( TFGameRules()->IsMannVsMachineMode() )
+	if ( FFGameRules()->IsMannVsMachineMode() )
 	{
 		if ( me->IsPlayerClass( CLASS_SPY ) )
 		{
@@ -251,11 +251,11 @@ Action< CFFBot > *CFFBotScenarioMonitor::DesiredScenarioAndClassAction( CFFBot *
 		// capture the flag
 		return new CFFBotFetchFlag;
 	}
-       else if ( TFGameRules()->GetGameType() == TF_GAMETYPE_CP )
+       else if ( FFGameRules()->GetGameType() == TF_GAMETYPE_CP )
        {
                // if we have a point we can capture - do it
 		CUtlVector< CTeamControlPoint * > captureVector;
-		TFGameRules()->CollectCapturePoints( me, &captureVector );
+		FFGameRules()->CollectCapturePoints( me, &captureVector );
 
 		if ( captureVector.Count() > 0 )
 		{
@@ -264,7 +264,7 @@ Action< CFFBot > *CFFBotScenarioMonitor::DesiredScenarioAndClassAction( CFFBot *
 
 		// otherwise, defend our point(s) from capture
 		CUtlVector< CTeamControlPoint * > defendVector;
-		TFGameRules()->CollectDefendPoints( me, &defendVector );
+		FFGameRules()->CollectDefendPoints( me, &defendVector );
 
 		if ( defendVector.Count() > 0 )
 		{

--- a/mp/src/game/server/ff/bot/behavior/tf_bot_seek_and_destroy.cpp
+++ b/mp/src/game/server/ff/bot/behavior/tf_bot_seek_and_destroy.cpp
@@ -58,7 +58,7 @@ ActionResult< CFFBot >	CFFBotSeekAndDestroy::Update( CFFBot *me, float interval 
 		return Done( "Behavior duration elapsed" );
 	}
 
-	if ( TFGameRules()->IsInTraining() )
+	if ( FFGameRules()->IsInTraining() )
 	{
 		// if the trainee has started capturing the point, assist them
 		if ( me->IsAnyPointBeingCaptured() )
@@ -83,7 +83,7 @@ ActionResult< CFFBot >	CFFBotSeekAndDestroy::Update( CFFBot *me, float interval 
 			}
 		}
 		
-		if ( !TFGameRules()->RoundHasBeenWon() && me->GetTimeLeftToCapture() < ff_bot_offense_must_push_time.GetFloat() )
+		if ( !FFGameRules()->RoundHasBeenWon() && me->GetTimeLeftToCapture() < ff_bot_offense_must_push_time.GetFloat() )
 		{
 			return Done( "Time to push for the objective" );
 		}
@@ -92,7 +92,7 @@ ActionResult< CFFBot >	CFFBotSeekAndDestroy::Update( CFFBot *me, float interval 
 	const CKnownEntity *threat = me->GetVisionInterface()->GetPrimaryKnownThreat();
 	if ( threat )
 	{
-		if ( TFGameRules()->RoundHasBeenWon() )
+		if ( FFGameRules()->RoundHasBeenWon() )
 		{
 			// hunt down the losers
 			return SuspendFor( new CFFBotAttack, "Chasing down the losers" );

--- a/mp/src/game/server/ff/bot/behavior/tf_bot_tactical_monitor.cpp
+++ b/mp/src/game/server/ff/bot/behavior/tf_bot_tactical_monitor.cpp
@@ -162,15 +162,15 @@ void CFFBotTacticalMonitor::AvoidBumpingEnemies( CFFBot *me )
 //-----------------------------------------------------------------------------------------
 ActionResult< CFFBot >	CFFBotTacticalMonitor::Update( CFFBot *me, float interval )
 {
-	if ( TFGameRules()->RoundHasBeenWon() )
+	if ( FFGameRules()->RoundHasBeenWon() )
 	{
 #ifdef TF_RAID_MODE
-		if ( TFGameRules()->IsBossBattleMode() )
+		if ( FFGameRules()->IsBossBattleMode() )
 		{
 			return Continue();
 		}
 #endif // TF_RAID_MODE
-		if ( TFGameRules()->GetWinningTeam() == me->GetTeamNumber() )
+		if ( FFGameRules()->GetWinningTeam() == me->GetTeamNumber() )
 		{
 			// we won - kill all losers we see
 			return SuspendFor( new CFFBotSeekAndDestroy, "Get the losers!" );
@@ -197,7 +197,7 @@ ActionResult< CFFBot >	CFFBotTacticalMonitor::Update( CFFBot *me, float interval
 		}
 	}
 
-	if ( TFGameRules()->State_Get() == GR_STATE_PREROUND )
+	if ( FFGameRules()->State_Get() == GR_STATE_PREROUND )
 	{
 		// clear stuck monitor so we dont jump when the preround elapses
 		me->GetLocomotionInterface()->ClearStuckStatus( "In preround" );
@@ -209,7 +209,7 @@ ActionResult< CFFBot >	CFFBotTacticalMonitor::Update( CFFBot *me, float interval
 		return SuspendFor( result, "Opportunistically using buff item" );
 	}
 
-	if ( TFGameRules()->InSetup() )
+	if ( FFGameRules()->InSetup() )
 	{
 		// if a human is staring at us, face them and taunt
 		if ( m_acknowledgeRetryTimer.IsElapsed() )
@@ -251,7 +251,7 @@ ActionResult< CFFBot >	CFFBotTacticalMonitor::Update( CFFBot *me, float interval
 	// check if we need to get to cover
 	QueryResultType shouldRetreat = me->GetIntentionInterface()->ShouldRetreat( me );
 
-	if ( TFGameRules()->IsMannVsMachineMode() )
+	if ( FFGameRules()->IsMannVsMachineMode() )
 	{
 		// never retreat in MvM mode
 		shouldRetreat = ANSWER_NO;
@@ -282,7 +282,7 @@ ActionResult< CFFBot >	CFFBotTacticalMonitor::Update( CFFBot *me, float interval
 
 	bool isAvailable = ( me->GetIntentionInterface()->ShouldHurry( me ) != ANSWER_YES );
 
-	if ( TFGameRules()->IsMannVsMachineMode() && me->HasTheFlag() )
+	if ( FFGameRules()->IsMannVsMachineMode() && me->HasTheFlag() )
 	{
 		isAvailable = false;
 	}
@@ -316,7 +316,7 @@ ActionResult< CFFBot >	CFFBotTacticalMonitor::Update( CFFBot *me, float interval
 
 		bool shouldDestroySentries = true;
 
-		if ( TFGameRules()->IsMannVsMachineMode() )
+		if ( FFGameRules()->IsMannVsMachineMode() )
 		{
 			shouldDestroySentries = false;
 		}

--- a/mp/src/game/server/ff/bot/map_entities/tf_bot_generator.cpp
+++ b/mp/src/game/server/ff/bot/map_entities/tf_bot_generator.cpp
@@ -246,8 +246,8 @@ void CFFBotGenerator::Activate()
 void CFFBotGenerator::GeneratorThink( void )
 {
 	// still waiting for the real game to start?
-	gamerules_roundstate_t roundState = TFGameRules()->State_Get();
-	if ( roundState >= GR_STATE_TEAM_WIN || roundState < GR_STATE_PREROUND ||  TFGameRules()->IsInWaitingForPlayers() )
+	gamerules_roundstate_t roundState = FFGameRules()->State_Get();
+	if ( roundState >= GR_STATE_TEAM_WIN || roundState < GR_STATE_PREROUND ||  FFGameRules()->IsInWaitingForPlayers() )
 	{
 		SetNextThink( gpGlobals->curtime + 1.0f );
 		return;
@@ -299,7 +299,7 @@ void CFFBotGenerator::SpawnBot( void )
 		m_spawnedBotVector.AddToTail( bot );
 
 #ifdef TF_RAID_MODE
-		if ( TFGameRules()->IsRaidMode() )
+		if ( FFGameRules()->IsRaidMode() )
 		{
 			bot->SetAttribute( CFFBot::IS_NPC );
 		}
@@ -381,7 +381,7 @@ void CFFBotGenerator::SpawnBot( void )
 		bot->HandleCommand_JoinClass( pClassName );
 
 		// in training, reset the after the bot joins the class
-		if ( TFGameRules()->IsInTraining() )
+		if ( FFGameRules()->IsInTraining() )
 		{
 			CFFBot::DifficultyType skill = bot->GetDifficulty();
 			CreateBotName( iTeam, bot->GetPlayerClass()->GetClassIndex(), skill, name, sizeof(name) );

--- a/mp/src/game/server/ff/bot/map_entities/tf_spawner.cpp
+++ b/mp/src/game/server/ff/bot/map_entities/tf_spawner.cpp
@@ -100,8 +100,8 @@ void CTFSpawner::OnKilled( CBaseEntity *dead )
 void CTFSpawner::SpawnerThink( void )
 {
 	// still waiting for the real game to start?
-	gamerules_roundstate_t roundState = TFGameRules()->State_Get();
-	if ( roundState >= GR_STATE_TEAM_WIN || roundState < GR_STATE_PREROUND ||  TFGameRules()->IsInWaitingForPlayers() )
+	gamerules_roundstate_t roundState = FFGameRules()->State_Get();
+	if ( roundState >= GR_STATE_TEAM_WIN || roundState < GR_STATE_PREROUND ||  FFGameRules()->IsInWaitingForPlayers() )
 	{
 		SetNextThink( gpGlobals->curtime + 1.0f );
 		return;

--- a/mp/src/game/server/ff/bot/map_entities/tf_spawner_boss.cpp
+++ b/mp/src/game/server/ff/bot/map_entities/tf_spawner_boss.cpp
@@ -91,8 +91,8 @@ void CTFSpawnerBoss::OnBotStunned( CBotNPC *pBot )
 void CTFSpawnerBoss::SpawnerThink( void )
 {
 	// still waiting for the real game to start?
-	gamerules_roundstate_t roundState = TFGameRules()->State_Get();
-	if ( roundState >= GR_STATE_TEAM_WIN || roundState < GR_STATE_PREROUND || TFGameRules()->IsInWaitingForPlayers() )
+	gamerules_roundstate_t roundState = FFGameRules()->State_Get();
+	if ( roundState >= GR_STATE_TEAM_WIN || roundState < GR_STATE_PREROUND || FFGameRules()->IsInWaitingForPlayers() )
 	{
 		SetNextThink( gpGlobals->curtime + 1.0f );
 		return;

--- a/mp/src/game/server/ff/bot/tf_bot.cpp
+++ b/mp/src/game/server/ff/bot/tf_bot.cpp
@@ -268,13 +268,13 @@ void CreateBotName( int iTeam, int iClassIndex, CFFBot::DifficultyType skill, ch
 	const char *pFriendlyOrEnemyTitle = "";
 
 	// @note (Tom Bui): it is okay to get localized name in training, since we should be on a listen server
-	if ( TFGameRules()->IsInTraining() )
+	if ( FFGameRules()->IsInTraining() )
 	{
 		// get the friendly/enemy title
 		const char *pBotTitle = NULL;
 		if ( iTeam != TEAM_UNASSIGNED )
 		{
-			int iHumanTeam = TFGameRules()->GetAssignedHumanTeam();
+			int iHumanTeam = FFGameRules()->GetAssignedHumanTeam();
 			if ( iHumanTeam != TEAM_ANY )
 			{
 				if ( iHumanTeam == iTeam )
@@ -387,7 +387,7 @@ CON_COMMAND_F( ff_bot_add, "Add a bot.", FCVAR_GAMEDLL )
 		iTeam = FF_TEAM_BLUE;
 	}
 
-	if ( TFGameRules()->IsInTraining() )
+	if ( FFGameRules()->IsInTraining() )
 	{
 		skill = CFFBot::EASY;
 	}
@@ -427,7 +427,7 @@ CON_COMMAND_F( ff_bot_add, "Add a bot.", FCVAR_GAMEDLL )
 			pBot->HandleCommand_JoinClass( thisClassname );
 
 			// set up a proper name now that we are in training
-			if ( TFGameRules()->IsInTraining() )
+			if ( FFGameRules()->IsInTraining() )
 			{
 				CreateBotName( pBot->GetTeamNumber(), pBot->GetPlayerClass()->GetClassIndex(), skill, name, sizeof(name) );
 				engine->SetFakeClientConVarValue( pBot->edict(), "name", name );
@@ -788,11 +788,11 @@ const char *CFFBot::GetNextSpawnClassname( void ) const
 	// assume offense
 	ClassSelectionInfo *desiredRoster = offenseRoster;
 	
-	if ( TFGameRules()->IsMatchTypeCompetitive() )
+	if ( FFGameRules()->IsMatchTypeCompetitive() )
 	{
 		desiredRoster = compRoster;
 	}
-	else if ( TFGameRules()->IsInKothMode() )
+	else if ( FFGameRules()->IsInKothMode() )
 	{
 		CTeamControlPoint *point = GetMyControlPoint();
 		if ( point )
@@ -804,13 +804,13 @@ const char *CFFBot::GetNextSpawnClassname( void ) const
 			}
 		}
 	}
-	else if ( TFGameRules()->GetGameType() == TF_GAMETYPE_CP )
+	else if ( FFGameRules()->GetGameType() == TF_GAMETYPE_CP )
 	{
 		CUtlVector< CTeamControlPoint * > captureVector;
-		TFGameRules()->CollectCapturePoints( const_cast< CFFBot * >( this ), &captureVector );
+		FFGameRules()->CollectCapturePoints( const_cast< CFFBot * >( this ), &captureVector );
 
 		CUtlVector< CTeamControlPoint * > defendVector;
-		TFGameRules()->CollectDefendPoints( const_cast< CFFBot * >( this ), &defendVector );
+		FFGameRules()->CollectDefendPoints( const_cast< CFFBot * >( this ), &defendVector );
 
 		// if we have any points we can capture, try to do so
 		if ( captureVector.Count() > 0 || defendVector.Count() == 0 )
@@ -822,7 +822,7 @@ const char *CFFBot::GetNextSpawnClassname( void ) const
 			desiredRoster = defenseRoster;
 		}
 	}
-	else if ( TFGameRules()->GetGameType() == TF_GAMETYPE_ESCORT )
+	else if ( FFGameRules()->GetGameType() == TF_GAMETYPE_ESCORT )
 	{
 		if ( GetTeamNumber() == FF_TEAM_RED )
 		{
@@ -838,7 +838,7 @@ const char *CFFBot::GetNextSpawnClassname( void ) const
 	{
 		ClassSelectionInfo *desiredClassInfo = &desiredRoster[ i ];
 
-		if ( TFGameRules()->CanBotChooseClass( const_cast< CFFBot * >( this ), desiredClassInfo->m_class ) == false )
+		if ( FFGameRules()->CanBotChooseClass( const_cast< CFFBot * >( this ), desiredClassInfo->m_class ) == false )
 		{
 			// not allowed to use this class
 			continue;
@@ -963,7 +963,7 @@ CFFBot::CFFBot()
 	m_attentionFocusEntity = NULL;
 	m_noisyTimer.Invalidate();
 
-	if ( TFGameRules()->IsInTraining() )
+	if ( FFGameRules()->IsInTraining() )
 	{
 		m_difficulty = CFFBot::EASY;
 	}
@@ -1102,9 +1102,9 @@ void CFFBot::PhysicsSimulate( void )
 	// If we're dead, choose a new class.
 	// We need to do this outside of the behavior system, since changing class can
 	// sometimes force an immediate respawn, which will destroy the bot's existing actions out from under it.
-	if ( !IsAlive() && !m_didReselectClass && ff_bot_keep_class_after_death.GetBool() == false && TFGameRules()->CanBotChangeClass( this ) )
+	if ( !IsAlive() && !m_didReselectClass && ff_bot_keep_class_after_death.GetBool() == false && FFGameRules()->CanBotChangeClass( this ) )
 	{
-		if ( TFGameRules() && TFGameRules()->IsMannVsMachineMode() )
+		if ( FFGameRules() && FFGameRules()->IsMannVsMachineMode() )
 			return;
 
 		const char *classname = FStrEq( ff_bot_force_class.GetString(), "" ) ? GetNextSpawnClassname() : ff_bot_force_class.GetString();
@@ -1148,7 +1148,7 @@ void CFFBot::AvoidPlayers( CUserCmd *pCmd )
 	Vector avoidVector = vec3_origin;
 
 	float tooClose = 50.0f;
-	if ( TFGameRules() && TFGameRules()->IsMannVsMachineMode() )
+	if ( FFGameRules() && FFGameRules()->IsMannVsMachineMode() )
 	{
 		// bots stay farther apart in MvM mode
 		tooClose = 150.0f;
@@ -1242,7 +1242,7 @@ void CFFBot::ChangeTeam( int iTeamNum, bool bAutoTeam, bool bSilent, bool bAutoB
 {
 	BaseClass::ChangeTeam( iTeamNum, bAutoTeam, bSilent, bAutoBalance );
 	
-	if ( TFGameRules()->IsMannVsMachineMode() )
+	if ( FFGameRules()->IsMannVsMachineMode() )
 	{
 		SetPrevMission( CFFBot::NO_MISSION );
 		ClearAllAttributes();
@@ -1256,7 +1256,7 @@ void CFFBot::ChangeTeam( int iTeamNum, bool bAutoTeam, bool bSilent, bool bAutoB
 bool CFFBot::ShouldGib( const CTakeDamageInfo &info )
 {
 	// only gib giant/miniboss
-	if ( TFGameRules()->IsMannVsMachineMode() && ( IsMiniBoss() || GetModelScale() > 1.f ) )
+	if ( FFGameRules()->IsMannVsMachineMode() && ( IsMiniBoss() || GetModelScale() > 1.f ) )
 	{
 		return true;
 	}
@@ -1361,7 +1361,7 @@ void CFFBot::Event_Killed( const CTakeDamageInfo &info )
 	}
 
 	// announce Spies
-	if ( TFGameRules()->IsMannVsMachineMode() )
+	if ( FFGameRules()->IsMannVsMachineMode() )
 	{
 		if ( IsPlayerClass( CLASS_SPY ) )
 		{
@@ -1439,11 +1439,11 @@ void CFFBot::Event_Killed( const CTakeDamageInfo &info )
 
 				if ( bEngineerTeleporterInTheWorld )
 				{
-					TFGameRules()->BroadcastSound( 255, "Announcer.MVM_An_Engineer_Bot_Is_Dead_But_Not_Teleporter" );
+					FFGameRules()->BroadcastSound( 255, "Announcer.MVM_An_Engineer_Bot_Is_Dead_But_Not_Teleporter" );
 				}
 				else
 				{
-					TFGameRules()->BroadcastSound( 255, "Announcer.MVM_An_Engineer_Bot_Is_Dead" );
+					FFGameRules()->BroadcastSound( 255, "Announcer.MVM_An_Engineer_Bot_Is_Dead" );
 				}
 			}
 		}
@@ -1531,7 +1531,7 @@ CTeamControlPoint *CFFBot::SelectPointToCapture( CUtlVector< CTeamControlPoint *
 		bool alwaysUseClosest = false;
 
 #ifdef STAGING_ONLY
-		alwaysUseClosest = TFGameRules() && TFGameRules()->IsBountyMode();
+		alwaysUseClosest = FFGameRules() && FFGameRules()->IsBountyMode();
 #endif // STAGING_ONLY
 
 		if ( IsPointBeingCaptured( closestPoint ) || alwaysUseClosest )
@@ -1628,10 +1628,10 @@ CTeamControlPoint *CFFBot::GetMyControlPoint( void ) const
 
 
 	CUtlVector< CTeamControlPoint * > captureVector;
-	TFGameRules()->CollectCapturePoints( const_cast< CFFBot * >( this ), &captureVector );
+	FFGameRules()->CollectCapturePoints( const_cast< CFFBot * >( this ), &captureVector );
 
 	CUtlVector< CTeamControlPoint * > defendVector;
-	TFGameRules()->CollectDefendPoints( const_cast< CFFBot * >( this ), &defendVector );
+	FFGameRules()->CollectDefendPoints( const_cast< CFFBot * >( this ), &defendVector );
 
 	if ( IsPlayerClass( CLASS_ENGINEER ) || IsPlayerClass( CLASS_SNIPER ) || HasAttribute( CFFBot::PRIORITIZE_DEFENSE ) )
 	{
@@ -1664,7 +1664,7 @@ CCaptureFlag *CFFBot::GetFlagToFetch( void ) const
 	int nCarriedFlags = 0;
 
 	// MvM Engineer bot never pick up a flag
-	if ( TFGameRules() && TFGameRules()->IsMannVsMachineMode() )
+	if ( FFGameRules() && FFGameRules()->IsMannVsMachineMode() )
 	{
 		if ( GetTeamNumber() == FF_TEAM_PVE_INVADERS && IsPlayerClass( CLASS_ENGINEER ) )
 		{
@@ -1676,7 +1676,7 @@ CCaptureFlag *CFFBot::GetFlagToFetch( void ) const
 			return NULL;
 		}
 
-		if ( TFGameRules()->IsMannVsMachineMode() && HasFlagTaget() )
+		if ( FFGameRules()->IsMannVsMachineMode() && HasFlagTaget() )
 		{
 			return GetFlagTarget();
 		}
@@ -1731,7 +1731,7 @@ CCaptureFlag *CFFBot::GetFlagToFetch( void ) const
 	CCaptureFlag *pClosestUncarriedFlag = NULL;
 	float flClosestUncarriedFlagDist = FLT_MAX;
 
-	if ( TFGameRules() && TFGameRules()->IsMannVsMachineMode() )
+	if ( FFGameRules() && FFGameRules()->IsMannVsMachineMode() )
 	{
 		int nMinFollower = INT_MAX;
 
@@ -1922,16 +1922,16 @@ bool CFFBot::IsNearPoint( CTeamControlPoint *point ) const
 // Return time left to capture the point before we lose the game
 float CFFBot::GetTimeLeftToCapture( void ) const
 {
-	if ( TFGameRules()->IsInKothMode() )
+	if ( FFGameRules()->IsInKothMode() )
 	{
-		if ( TFGameRules()->GetKothTeamTimer( GetEnemyTeam( GetTeamNumber() ) ) )
+		if ( FFGameRules()->GetKothTeamTimer( GetEnemyTeam( GetTeamNumber() ) ) )
 		{
-			return TFGameRules()->GetKothTeamTimer( GetEnemyTeam( GetTeamNumber() ) )->GetTimeRemaining();
+			return FFGameRules()->GetKothTeamTimer( GetEnemyTeam( GetTeamNumber() ) )->GetTimeRemaining();
 		}
 	}
-	else if ( TFGameRules()->GetActiveRoundTimer() )
+	else if ( FFGameRules()->GetActiveRoundTimer() )
 	{
-		return TFGameRules()->GetActiveRoundTimer()->GetTimeRemaining();
+		return FFGameRules()->GetActiveRoundTimer()->GetTimeRemaining();
 	}
 
 	return 0.0f;
@@ -1946,7 +1946,7 @@ void CFFBot::SetupSniperSpotAccumulation( void )
 
 	CBaseEntity *goalEntity = NULL;
 
-       if ( TFGameRules()->GetGameType() == TF_GAMETYPE_CP )
+       if ( FFGameRules()->GetGameType() == TF_GAMETYPE_CP )
        {
                goalEntity = GetMyControlPoint();
        }
@@ -1977,7 +1977,7 @@ void CFFBot::SetupSniperSpotAccumulation( void )
 	bool isDefendingPoint = false;
 	CTFNavArea *goalEntityArea = NULL;
 
-	if ( TFGameRules()->GetGameType() == TF_GAMETYPE_ESCORT )
+	if ( FFGameRules()->GetGameType() == TF_GAMETYPE_ESCORT )
 	{
 		// the cart is owned by the invaders
 		isDefendingPoint = ( goalEntity->GetTeamNumber() != myTeam );
@@ -2764,7 +2764,7 @@ float CFFBot::GetMaxAttackRange( void ) const
 	
 	if ( myWeapon->IsWeapon( FF_WEAPON_FLAMETHROWER ) )
 	{
-		if ( TFGameRules()->IsMannVsMachineMode() )
+		if ( FFGameRules()->IsMannVsMachineMode() )
 		{
 			const float flameRange = 350.0f;
 
@@ -2830,7 +2830,7 @@ float CFFBot::GetDesiredAttackRange( void ) const
 		return FLT_MAX;
 	}
 
-	if ( myWeapon->IsWeapon( FF_WEAPON_ROCKETLAUNCHER ) && !TFGameRules()->IsMannVsMachineMode() )
+	if ( myWeapon->IsWeapon( FF_WEAPON_ROCKETLAUNCHER ) && !FFGameRules()->IsMannVsMachineMode() )
 	{
 		return 1250.0f;
 	}
@@ -2851,7 +2851,7 @@ bool CFFBot::EquipRequiredWeapon( void )
 		return Weapon_Switch( pWeapon );
 	}
 
-	if ( TheTFBots().IsMeleeOnly() || TFGameRules()->IsInMedievalMode() || HasWeaponRestriction( MELEE_ONLY ) )
+	if ( TheTFBots().IsMeleeOnly() || FFGameRules()->IsInMedievalMode() || HasWeaponRestriction( MELEE_ONLY ) )
 	{
 		// force use of melee weapons
 		Weapon_Switch( Weapon_GetSlot( TF_WPN_TYPE_MELEE ) );
@@ -2882,7 +2882,7 @@ void CFFBot::EquipBestWeaponForThreat( const CKnownEntity *threat )
 		return;
 
 #ifdef TF_RAID_MODE
-	if ( TFGameRules()->IsRaidMode() )
+	if ( FFGameRules()->IsRaidMode() )
 	{
 		if ( HasAttribute( CFFBot::AGGRESSIVE ) )
 		{
@@ -2912,7 +2912,7 @@ void CFFBot::EquipBestWeaponForThreat( const CKnownEntity *threat )
 	}
 
 	// no secondary weapons in MvM
-	if ( TFGameRules()->IsMannVsMachineMode() )
+	if ( FFGameRules()->IsMannVsMachineMode() )
 	{
 		if ( IsPlayerClass( CLASS_MEDIC ) && IsInASquad() && GetSquad() && !GetSquad()->IsLeader( this ) )
 		{
@@ -3059,7 +3059,7 @@ void CFFBot::EquipBestWeaponForThreat( const CKnownEntity *threat )
 bool CFFBot::EquipLongRangeWeapon( void )
 {
 	// no secondary weapons in MvM
-	if ( TFGameRules()->IsMannVsMachineMode() )
+	if ( FFGameRules()->IsMannVsMachineMode() )
 		return false;
 
 	if ( IsPlayerClass( CLASS_SOLDIER ) || 
@@ -3686,7 +3686,7 @@ bool CFFBot::IsWeaponRestricted( CFFWeaponBase *weapon ) const
 //
 bool CFFBot::ShouldFireCompressionBlast( void )
 {
-	if ( TFGameRules()->IsInTraining() )
+	if ( FFGameRules()->IsInTraining() )
 	{
 		// no reflection in training mode
 		return false;
@@ -3719,7 +3719,7 @@ bool CFFBot::ShouldFireCompressionBlast( void )
 		}
 	}
 
-	bool shouldPushPlayers = !TFGameRules()->IsMannVsMachineMode();
+	bool shouldPushPlayers = !FFGameRules()->IsMannVsMachineMode();
 
 	if ( shouldPushPlayers )
 	{
@@ -4167,7 +4167,7 @@ Action< CFFBot > *CFFBot::OpportunisticallyUseWeaponAbilities( void )
 	}
 
 	// don't use items if we have the flag, since most of them are unusable (unless we're a bomb carrier in MvM)
-	if ( HasTheFlag() && !TFGameRules()->IsMannVsMachineMode() )
+	if ( HasTheFlag() && !FFGameRules()->IsMannVsMachineMode() )
 	{
 		return NULL;
 	}
@@ -4259,7 +4259,7 @@ void CFFBot::StartIdleSound( void )
 {
 	StopIdleSound();
 
-	if ( TFGameRules() && !TFGameRules()->IsMannVsMachineMode() )
+	if ( FFGameRules() && !FFGameRules()->IsMannVsMachineMode() )
 		return;
 
 	// SHIELD YOUR EYES MIKEB!!!
@@ -4415,7 +4415,7 @@ void CFFBot::OnEventChangeAttributes( const CFFBot::EventChangeAttributes_t* pEv
 
 		SetMaxVisionRangeOverride( pEvent->m_maxVisionRange );
 
-		if ( TFGameRules()->IsMannVsMachineMode() )
+		if ( FFGameRules()->IsMannVsMachineMode() )
 		{
 			SetAttribute( CFFBot::BECOME_SPECTATOR_ON_DEATH );
 			SetAttribute( CFFBot::RETAIN_BUILDINGS );

--- a/mp/src/game/server/ff/bot/tf_bot.h
+++ b/mp/src/game/server/ff/bot/tf_bot.h
@@ -890,7 +890,7 @@ public:
 			}
 
 			// in training, avoid capturing the point until the human trainee does so
-			if ( TFGameRules()->IsInTraining() && 
+			if ( FFGameRules()->IsInTraining() && 
 				 area->HasAttributeTF( FF_NAV_CONTROL_POINT ) && 
 				 !m_me->IsAnyPointBeingCaptured() &&
 				 !m_me->IsPlayerClass( CLASS_ENGINEER ) )	// allow engineers to path so they can test travel distance for sentry placement
@@ -902,7 +902,7 @@ public:
 			if ( ( m_me->GetTeamNumber() == FF_TEAM_RED && area->HasAttributeTF( FF_NAV_SPAWN_ROOM_BLUE ) ) ||
 				 ( m_me->GetTeamNumber() == FF_TEAM_BLUE && area->HasAttributeTF( FF_NAV_SPAWN_ROOM_RED ) ) )
 			{
-				if ( !TFGameRules()->RoundHasBeenWon() )
+				if ( !FFGameRules()->RoundHasBeenWon() )
 				{
 					return -1.0f;
 				}

--- a/mp/src/game/server/ff/bot/tf_bot_body.cpp
+++ b/mp/src/game/server/ff/bot/tf_bot_body.cpp
@@ -18,7 +18,7 @@ float CFFBotBody::GetHeadAimTrackingInterval( void ) const
 	CFFBot *me = (CFFBot *)GetBot();
 
 	// don't let Spies in MvM mode aim too precisely
-	if ( TFGameRules()->IsMannVsMachineMode() && me->IsPlayerClass( CLASS_SPY ) )
+	if ( FFGameRules()->IsMannVsMachineMode() && me->IsPlayerClass( CLASS_SPY ) )
 	{
 		return 0.25f;
 	}

--- a/mp/src/game/server/ff/bot/tf_bot_locomotion.cpp
+++ b/mp/src/game/server/ff/bot/tf_bot_locomotion.cpp
@@ -41,7 +41,7 @@ void CFFBotLocomotion::Update( void )
 // Move directly towards the given position
 void CFFBotLocomotion::Approach( const Vector &pos, float goalWeight )
 {
-	if ( TFGameRules()->IsMannVsMachineMode() )
+	if ( FFGameRules()->IsMannVsMachineMode() )
 	{
 		if ( !IsOnGround() && !IsClimbingOrJumping() )
 		{
@@ -83,7 +83,7 @@ bool CFFBotLocomotion::IsAreaTraversable( const CNavArea *baseArea ) const
 		return false;
 	}
 
-	if ( !TFGameRules()->RoundHasBeenWon() || TFGameRules()->GetWinningTeam() != me->GetTeamNumber() )
+	if ( !FFGameRules()->RoundHasBeenWon() || FFGameRules()->GetWinningTeam() != me->GetTeamNumber() )
 	{
 		if ( area->HasAttributeTF( TF_NAV_SPAWN_ROOM_RED ) && me->GetTeamNumber() == FF_TEAM_BLUE )
 		{
@@ -123,7 +123,7 @@ void CFFBotLocomotion::Jump( void )
 		return;
 	}
 
-	if ( TFGameRules() && TFGameRules()->IsMannVsMachineMode() )
+	if ( FFGameRules() && FFGameRules()->IsMannVsMachineMode() )
 	{
 		int iCustomJumpParticle = 0;
 		CALL_ATTRIB_HOOK_INT_ON_OTHER( me, iCustomJumpParticle, bot_custom_jump_particle );

--- a/mp/src/game/server/ff/bot/tf_bot_manager.cpp
+++ b/mp/src/game/server/ff/bot/tf_bot_manager.cpp
@@ -140,7 +140,7 @@ void CFFBotManager::OnRoundRestart( void )
 	}
 
 
-#ifdef TF_CREEP_MODE
+#ifdef FF_CREEP_MODE
 	m_creepExperience[ FF_TEAM_RED ] = 0;
 	m_creepExperience[ FF_TEAM_BLUE ] = 0;
 #endif
@@ -156,7 +156,7 @@ void CFFBotManager::Update()
 
 	DrawStuckBotData();
 
-#ifdef TF_CREEP_MODE
+#ifdef FF_CREEP_MODE
 	UpdateCreepWaves();
 #endif
 
@@ -164,7 +164,7 @@ void CFFBotManager::Update()
 }
 
 
-#ifdef TF_CREEP_MODE
+#ifdef FF_CREEP_MODE
 ConVar ff_creep_initial_delay( "ff_creep_initial_delay", "30" );
 ConVar ff_creep_wave_interval( "ff_creep_wave_interval", "30" );
 ConVar ff_creep_wave_count( "ff_creep_wave_count", "3" );
@@ -175,16 +175,16 @@ ConVar ff_creep_level_up( "ff_creep_level_up", "6" );
 //----------------------------------------------------------------------------------------------------------------
 void CFFBotManager::UpdateCreepWaves()
 {
-	if ( !TFGameRules()->IsCreepWaveMode() )
+	if ( !FFGameRules()->IsCreepWaveMode() )
 		return;
 
-	if ( TFGameRules()->RoundHasBeenWon() )
+	if ( FFGameRules()->RoundHasBeenWon() )
 	{
 		// no more creep waves - game is over
 		return;
 	}
 
-	if ( TFGameRules()->InSetup() || TFGameRules()->State_Get() == GR_STATE_STARTGAME || TFGameRules()->State_Get() == GR_STATE_PREROUND )
+	if ( FFGameRules()->InSetup() || FFGameRules()->State_Get() == GR_STATE_STARTGAME || FFGameRules()->State_Get() == GR_STATE_PREROUND )
 	{
 		// no creeps at start of round
 		m_creepWaveTimer.Start( ff_creep_initial_delay.GetFloat() );
@@ -275,7 +275,7 @@ void CFFBotManager::OnCreepKilled( CFFPlayer *killer )
 	UTIL_ClientPrintAll( HUD_PRINTTALK, "%s killed a creep" );
 }
 
-#endif // TF_CREEP_MODE
+#endif // FF_CREEP_MODE
 
 //----------------------------------------------------------------------------------------------------------------
 bool CFFBotManager::RemoveBotFromTeamAndKick( int nTeam )
@@ -359,11 +359,11 @@ void CFFBotManager::MaintainBotQuota()
 		return;
 
 	// new players can't spawn immediately after the round has been going for some time
-	if ( !TFGameRules() )
+	if ( !FFGameRules() )
 		return;
 
 	// training mode controls the bots
-	if ( TFGameRules()->IsInTraining() )
+	if ( FFGameRules()->IsInTraining() )
 		return;
 
 	// if it is not time to do anything...
@@ -460,8 +460,8 @@ void CFFBotManager::MaintainBotQuota()
 	if ( desiredBotCount > nTFBotsOnGameTeams )
 	{
 		// don't try to add a bot if it would unbalance
-		if ( !TFGameRules()->WouldChangeUnbalanceTeams( FF_TEAM_BLUE, TEAM_UNASSIGNED ) ||
-			 !TFGameRules()->WouldChangeUnbalanceTeams( FF_TEAM_RED, TEAM_UNASSIGNED ) )
+		if ( !FFGameRules()->WouldChangeUnbalanceTeams( FF_TEAM_BLUE, TEAM_UNASSIGNED ) ||
+			 !FFGameRules()->WouldChangeUnbalanceTeams( FF_TEAM_RED, TEAM_UNASSIGNED ) )
 		{
 			CFFBot *pBot = GetAvailableBotFromPool();
 			if ( pBot == NULL )
@@ -571,7 +571,7 @@ bool CFFBotManager::IsAllBotTeam( int iTeam )
 
 	// okay, this is a bit trickier...
 	// if there are no people on this team, then we need to check the "assigned" human team
-	return TFGameRules()->GetAssignedHumanTeam() != iTeam;
+	return FFGameRules()->GetAssignedHumanTeam() != iTeam;
 }
 
 

--- a/mp/src/game/server/ff/bot/tf_bot_squad.cpp
+++ b/mp/src/game/server/ff/bot/tf_bot_squad.cpp
@@ -25,7 +25,7 @@ void CFFBotSquad::Join( CFFBot *bot )
 	{
 		m_leader = bot;
 	}
-	else if ( TFGameRules() && TFGameRules()->IsMannVsMachineMode() )
+	else if ( FFGameRules() && FFGameRules()->IsMannVsMachineMode() )
 	{
 		bot->SetFlagTarget( NULL );
 	}
@@ -54,7 +54,7 @@ void CFFBotSquad::Leave( CFFBot *bot )
 			}
 		}
 	}
-	else if ( TFGameRules() && TFGameRules()->IsMannVsMachineMode() )
+	else if ( FFGameRules() && FFGameRules()->IsMannVsMachineMode() )
 	{
 		AssertMsg( !bot->HasFlagTaget(), "Squad member shouldn't have a flag target. Always follow the leader." );
 		CCaptureFlag *pFlag = bot->GetFlagToFetch();

--- a/mp/src/game/server/ff/bot/tf_bot_vision.cpp
+++ b/mp/src/game/server/ff/bot/tf_bot_vision.cpp
@@ -20,7 +20,7 @@ ConVar ff_bot_sniper_choose_target_interval( "ff_bot_sniper_choose_target_interv
 // Update internal state
 void CFFBotVision::Update( void )
 {
-	if ( TFGameRules()->IsMannVsMachineMode() )
+	if ( FFGameRules()->IsMannVsMachineMode() )
 	{
 		// Throttle vision update rate of robots in MvM for perf at the expense of reaction times
 		if ( !m_scanTimer.IsElapsed() )
@@ -109,7 +109,7 @@ void CFFBotVision::UpdatePotentiallyVisibleNPCVector( void )
 		// collect list of active buildings
 		m_potentiallyVisibleNPCVector.RemoveAll();
 
-		bool bShouldSeeTeleporter = !TFGameRules()->IsMannVsMachineMode() || GetBot()->GetEntity()->GetTeamNumber() != FF_TEAM_PVE_INVADERS;
+		bool bShouldSeeTeleporter = !FFGameRules()->IsMannVsMachineMode() || GetBot()->GetEntity()->GetTeamNumber() != FF_TEAM_PVE_INVADERS;
 		for ( int i=0; i<IBaseObjectAutoList::AutoList().Count(); ++i )
 		{
 			CBaseObject* pObj = static_cast< CBaseObject* >( IBaseObjectAutoList::AutoList()[i] );
@@ -152,7 +152,7 @@ bool CFFBotVision::IsIgnored( CBaseEntity *subject ) const
 	CFFBot *me = (CFFBot *)GetBot()->GetEntity();
 
 #ifdef TF_RAID_MODE
-	if ( TFGameRules()->IsRaidMode() )
+	if ( FFGameRules()->IsRaidMode() )
 	{
 		if ( me->IsPlayerClass( CLASS_SCOUT ) )
 		{
@@ -316,7 +316,7 @@ bool CFFBotVision::IsIgnored( CBaseEntity *subject ) const
 			{
 				// unless we're in MvM where buildings can have really large health pools,
 				// so an engineer can die and run back in time to repair their stuff
-				if ( TFGameRules() && TFGameRules()->IsMannVsMachineMode() )
+				if ( FFGameRules() && FFGameRules()->IsMannVsMachineMode() )
 				{
 					return false;
 				}
@@ -392,7 +392,7 @@ bool CFFBotVision::IsVisibleEntityNoticed( CBaseEntity *subject ) const
 			return false;
 		}
 
-		if ( TFGameRules()->IsMannVsMachineMode() )	// in MvM mode, forget spies as soon as they are fully disguised
+		if ( FFGameRules()->IsMannVsMachineMode() )	// in MvM mode, forget spies as soon as they are fully disguised
 		{
 			CFFBot::SuspectedSpyInfo_t* pSuspectInfo = me->IsSuspectedSpy( player );
 			// But only if we aren't suspecting them currently.  This happens when we bump into them.
@@ -411,7 +411,7 @@ bool CFFBotVision::IsVisibleEntityNoticed( CBaseEntity *subject ) const
 			return true;
 		}
 
-		if ( !TFGameRules()->IsMannVsMachineMode() )	// ignore in MvM mode
+		if ( !FFGameRules()->IsMannVsMachineMode() )	// ignore in MvM mode
 		{
 			if ( player->IsPlacingSapper() )
 			{

--- a/mp/src/game/shared/ff/ff_gamerules.h
+++ b/mp/src/game/shared/ff/ff_gamerules.h
@@ -1,4 +1,5 @@
-//========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
+#include "tf/tf_shareddefs.h"
+//========= Copyright Â© 1996-2005, Valve Corporation, All rights reserved. ============//
 //
 // Purpose: The TF Game rules object
 //
@@ -176,6 +177,7 @@ public:
 	// display game description on discord rich presence
 	// clients should not be able to use this, obviously
 	virtual void	SetGameDescription(const char* szGameDescription);
+        virtual int GetGameType( void ) const { return TF_GAMETYPE_CTF; }
 
 //private:
 //	CFFMapFilter	m_hMapFilter;


### PR DESCRIPTION
## Summary
- replace `TFGameRules` calls with `FFGameRules`
- rename `TF_CREEP_MODE` checks to `FF_CREEP_MODE`
- add TF game type include in `ff_gamerules.h`
- provide a basic `GetGameType` implementation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d0f131d148330bbdbbde7eb448d79